### PR TITLE
Update `make/extern/mpi/init.mm`

### DIFF
--- a/make/extern/mpi/init.mm
+++ b/make/extern/mpi/init.mm
@@ -36,7 +36,7 @@ mpi.libpath ?= $(mpi.dir)/lib
 mpi.rpath = $(mpi.libpath)
 # the names of the libraries are flavor dependent
 mpi.libraries := \
-    ${if ${findstring openmpi,$(mpi.flavor)},mpi_cxx mpi $(mpi.required),}
+    ${if ${findstring openmpi,$(mpi.flavor)}, mpi $(mpi.required),}
 
 
 # end of file


### PR DESCRIPTION
... to remove `libmpi_cxx` C++ bindings deprecated in OpenMPI version 3 and removed in version 5