### PR TITLE
Fix setting mpi.libraries for mpich flavor of MPI

### DIFF
--- a/make/extern/mpi/init.mm
+++ b/make/extern/mpi/init.mm
@@ -42,6 +42,9 @@ mpi.libraries := \
          mpi_cxx mpi, \
          mpi \
        } \
+    } \
+    ${if ${findstring mpich,$(mpi.flavor)},\
+         mpi pmpi \
     }
 
 


### PR DESCRIPTION
Setting `mpi.libraries` in `make/extern/mpi/init.mm` was missing for `mpich`.

Closes #25 