### PR TITLE
docs: add project documentation and fix inaccuracies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+`mm` and `mm.py` host the Python front-end that inspects a project and invokes GNU Make. Platform, language, and library presets live in `make/` (e.g., `make/compilers/intel.mm`). Headers sit in `include/mm/`, docs in `docs/`, and samples in `examples/`. Each sample mirrors real deployments: `.mm/{project}.mm` declares the build graph, `lib/` and `pkg/` store C++/Python sources, and `tests/` hold integration checks.
+
+## Build, Test, and Development Commands
+- `./install.sh ~/.local && export PATH="$HOME/.local/bin:$PATH"` bootstraps a user install for local testing.
+- `./mm --help` shows all command-line options; `mm <project>.help` and `mm <asset>.info` provide runtime target information.
+- `./mm --target=opt,static --show` exercises optimized/static variants and shows the generated make line.
+- `./mm --prefix=/tmp/mm-dev products` writes artifacts into a scratch prefix before publishing.
+- `./mm test` or `./mm test hello.pkg --target=cov` runs all tests or a focused suite with coverage objects.
+
+## Coding Style & Naming Conventions
+Python sources (`mm.py`, `examples/hello/pkg/`) follow PEP 8: four-space indents, descriptive snake_case, f-strings, and module docstrings outlining CLI verbs. C++/Fortran samples under `examples/hello/lib/hello` use `.cc/.h`, four-space blocks, directory-mirroring namespaces (e.g., `hello::greetings`), STL types, and `static` helpers for internal linkage. Make fragments rely on lowercase, dot-delimited identifiers (`component.kind.setting := value`) and `:=` assignments; keep new knobs consistent.
+
+## Testing Guidelines
+Scenario tests live beside their feature (`examples/hello/tests`, `make/tests`). Follow the `component.variant` naming pattern (`hello.lib`, `hello.pkg`) and keep fixtures tiny so they run in seconds. Always run `./mm test` before opening a PR, paste the command in the description, and prefer `./mm test --target=cov` when touching discovery or planner code. Toolchain updates should include a smoke target in `examples/prep` that proves the new compiler or flag set.
+
+## Commit & Pull Request Guidelines
+Git history favors short, imperative summaries (`added intel compilers`, `removed c++20 as default`). Keep subjects under 72 characters, elaborate below when context is subtle, and optionally prefix scope (`docs:`, `examples:`). PRs need a problem statement, brief change bullets, the `./mm test` command you ran, linked issues, and screenshots/logs for user-visible changes. Tag maintainers for the impacted subsystem and wait for one passing run plus a maintainer approval before merging.
+
+## Configuration Tips
+mm derives everything from `.mm/{project}.mm`. Use `mylib.lib.root := lib/mylib/` style assignments, keep secrets out of configs, and prefer environment overrides (`mm_prefix`, `mm_targets`) instead of editing tracked files for personal setups. When sharing new presets, document external toolchains in `docs/` and gate optional features behind `ifdef <dependency>.dir` blocks so default builds stay portable.

--- a/README.md
+++ b/README.md
@@ -64,5 +64,5 @@ Quick start:
 cd your-project
 mm            # Build with default targets (debug, shared)
 mm test       # Run tests
-mm --target=opt,static  # Build optimized static variant
+mm --target=opt         # Build optimized variant
 ```

--- a/docs/DOCUMENTATION_PLAN.md
+++ b/docs/DOCUMENTATION_PLAN.md
@@ -1,0 +1,104 @@
+# mm Documentation Plan
+
+## Current Status
+
+### Completed
+
+1. **README.md** - Enhanced front page with quick start, feature highlights, and
+   bash completion documentation.
+
+2. **docs/quickstart.md** - Comprehensive guide covering installation,
+   C++ library example, auto-discovery, Python packages/extensions, external
+   dependencies, build targets, configuration hierarchy, host-specific config,
+   environment variables, and shell integration.
+
+3. **docs/FAQ.md** - 30+ common questions covering getting started,
+   configuration, building, testing, advanced topics, and troubleshooting.
+
+4. **docs/examples.md** - In-depth walkthrough of `examples/hello/` with
+   project structure, build output, test setup, and conditional compilation.
+
+5. **docs/command-line-reference.md** - Full option reference for mm.py v4.5
+   (the current `mm.py` front-end).
+
+6. **etc/bash_completion/mm** - Bash tab completion with dynamic target
+   discovery, option completion, and inline help (merged in PR #29).
+
+### Runtime Help
+
+mm provides runtime help through make targets (no `--guide` flag exists):
+
+```bash
+mm --help              # Command-line options
+mm <project>.help      # List available targets
+mm <asset>.info        # Show asset configuration
+mm builder.info.help   # List all info targets
+mm host.info           # Host platform details
+```
+
+## Remaining Documentation Tasks
+
+### Phase 2: Task-Oriented Guides (Priority: HIGH)
+
+Create `docs/guides/` with:
+
+1. **creating-a-library.md** - Single/multi-directory, header-only, static vs shared
+2. **creating-a-python-package.md** - Pure Python, mixed Python/C++
+3. **creating-an-extension.md** - C++ to Python bindings
+4. **external-dependencies.md** - Pre-configured packages, custom packages
+5. **tests-and-ci.md** - Test discovery, test cases, CI integration
+
+### Phase 3: Reference Documentation (Priority: MEDIUM)
+
+Create `docs/reference/` with:
+
+1. **configuration-variables.md** - All project/asset/compiler variables
+2. **build-targets.md** - Target variants with compiler flags per toolchain:
+   - `debug` - `-g`, defines `DEBUG`
+   - `opt` - `-O3`
+   - `shared` - `-fPIC`, builds `.so`
+   - `prof` - `-pg` profiling
+   - `cov` - `--coverage` for gcov/lcov
+   - `reldeb` - `-g -O`, release with debug info
+   - Note: `static` is not a built-in variant; omit `shared` to get static-only
+3. **external-packages.md** - Complete list of pre-configured extern packages
+4. **supported-languages.md** - C, C++, Fortran, CUDA, Python, Cython, JavaScript
+
+### Phase 4: Architecture & Extension (Priority: LOW)
+
+1. **design-philosophy.md** - Why Python + Make, convention over configuration
+2. **python-make-boundary.md** - What Python vs Make each handle
+3. **makefile-organization.md** - The make fragment library explained
+4. **adding-new-languages.md** - Language support checklist
+
+### Notes
+
+- mm has two Python front-ends: `mm.py` (v4.5.0, 1097 lines) and `mm`
+  (v5.0.0, 1316 lines). Current docs cover `mm.py`. The v5 `mm` adds
+  `--pkgdb`, `--version`, `--bin-prefix`, `--lib-prefix`, and renames
+  `--ruledb` to `--rules`.
+- `examples/prep/` contains test dependency examples (not preprocessing).
+- `examples/simple/` uses a minimal include-based pattern.
+
+## Documentation Style Guide
+
+### Principles
+1. **Show, don't tell** - Working examples over theory
+2. **Progressive disclosure** - Simple first, complexity later
+3. **Copy-paste ready** - All examples should be executable
+4. **Real-world** - Use patterns from actual projects
+5. **Concise** - Respect the reader's time
+
+### Format
+- Use shell code blocks for commands
+- Use `makefile` syntax highlighting for .mm files
+- Include expected output where helpful
+- Always show the "why" not just the "how"
+
+## Success Metrics
+
+Documentation is successful when:
+1. New user can build first project in <5 minutes
+2. Common tasks don't require reading source code
+3. Users can find answers via grep/search
+4. Examples cover 80% of real use cases

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,377 @@
+# mm Frequently Asked Questions
+
+## Getting Started
+
+### Q: Do I need to write makefiles?
+
+**No.** That's the whole point of mm. You only need one configuration file: `.mm/{project}.mm`
+
+The configuration file just declares *what* you're building:
+```makefile
+myproject.libraries := mylib.lib
+mylib.lib.stem := mylib
+mylib.lib.root := lib/mylib/
+```
+
+mm automatically discovers all source files and generates the makefiles.
+
+### Q: How does mm find my source files?
+
+mm scans the directory specified in `{library}.root` and automatically finds all `.cc`, `.c`, `.cu`, `.f`, etc. files.
+
+For large projects, you can specify which subdirectories to scan:
+```makefile
+mylib.lib.root := src/
+mylib.lib.directories := geometry/ physics/ io/
+```
+
+### Q: Where do build products go?
+
+By default:
+- **Intermediate files** (`.o`, `.d`): `builds/{target}/`
+- **Final products**: `products/{bin,lib,include,packages}/`
+
+You can override with `--prefix` or `--bldroot`.
+
+### Q: Can I have multiple build configurations?
+
+Yes! Use `--target`:
+```bash
+mm --target=debug        # Debug build
+mm --target=opt          # Optimized build  
+mm --target=opt,shared   # Optimized + shared libs
+```
+
+Each target gets its own directory in `builds/`.
+
+## Configuration
+
+### Q: Where should I configure external dependencies?
+
+Three places, in order of preference:
+
+1. **User config** (`~/.mm/config.mm`) - for system-wide packages
+2. **Host config** (`~/.mm/{user}@{host}.mm`) - for machine-specific paths
+3. **Project config** (`.mm/{project}.mm`) - rarely needed, usually not the right place
+
+Example in `~/.mm/config.mm`:
+```makefile
+cuda.dir := /usr/local/cuda-12.0
+cuda.incpath := $(cuda.dir)/include
+cuda.libpath := $(cuda.dir)/lib64
+```
+
+### Q: How do I use a dependency that's already configured?
+
+Just add it to `extern`:
+```makefile
+mylib.lib.extern := mpi cuda hdf5 gsl
+```
+
+mm knows about 20+ packages. See the quickstart for the full list.
+
+### Q: What if my dependency isn't pre-configured?
+
+Add it to your `~/.mm/config.mm`:
+```makefile
+# My custom library
+mypackage.version := 1.0
+mypackage.dir := /opt/mypackage
+mypackage.incpath := $(mypackage.dir)/include
+mypackage.libpath := $(mypackage.dir)/lib
+mypackage.libraries := mylib1 mylib2
+```
+
+Then use: `mylib.lib.extern := mypackage`
+
+### Q: How do I set compiler flags?
+
+In your `.mm/{project}.mm`:
+```makefile
+# For a specific library
+mylib.lib.c++.flags := -Wall -O3 $($(compiler.c++).std.c++20)
+
+# For all libraries in the project
+myproject.common.c++.flags := -Wall -O3
+${foreach lib, $(myproject.libraries), \
+    ${eval $(lib).c++.flags := $(myproject.common.c++.flags)} \
+}
+```
+
+### Q: Can I use environment variables?
+
+Yes:
+```bash
+export mm_prefix=/opt/myproject
+export mm_targets="opt,shared"
+export mm_compiler=gcc
+
+mm
+```
+
+This is useful for CI/CD and environment modules.
+
+## Building
+
+### Q: How do I do a clean build?
+
+```bash
+# Remove all build artifacts
+rm -rf builds products
+mm
+```
+
+mm also provides make-level clean targets: `mm clean` removes build products,
+`mm tidy` removes intermediate objects, and `mm tests.clean` removes test
+artifacts.  For a guaranteed fresh start, removing the directories is simplest.
+
+### Q: How do I build in parallel?
+
+mm builds in parallel by default, using all CPU cores.
+
+Control it with:
+```bash
+mm -j 8          # Use 8 cores
+mm --serial      # Single-threaded (for debugging)
+```
+
+### Q: How do I see what mm is doing?
+
+```bash
+mm --show        # Show the make command
+mm --verbose     # Show all compiler commands
+```
+
+### Q: My build is failing. How do I debug?
+
+1. **See the actual commands**: `mm --verbose`
+2. **Build serially**: `mm --serial --verbose` (cleaner output)
+3. **Check configuration**: `mm --show`
+4. **Dry run**: `mm --dry` (shows what would happen)
+
+### Q: Can I pass arguments to make?
+
+Yes, everything after `mm` options goes to make:
+```bash
+mm some-target           # Build specific target
+mm VERBOSE=1             # Make variable
+mm --target=debug test   # Build tests in debug mode
+```
+
+## Projects & Dependencies
+
+### Q: How do I link one library to another in the same project?
+
+Use `prerequisites`:
+```makefile
+myproject.libraries := base.lib derived.lib
+
+derived.lib.prerequisites := base.lib
+derived.lib.extern := base.lib
+```
+
+### Q: How do I build Python extensions?
+
+```makefile
+myproject.libraries := mylib.lib
+myproject.packages := myapp.pkg
+myproject.extensions := myext.ext
+
+myext.ext.stem := myext
+myext.ext.pkg := myapp.pkg          # Install into this package
+myext.ext.wraps := mylib.lib        # Link against this library
+myext.ext.extern := mylib.lib python
+```
+
+### Q: Can I exclude specific source files?
+
+Yes:
+```makefile
+mylib.lib.sources.exclude := \
+    src/old_code.cc \
+    src/broken.cc
+
+mylib.lib.headers.exclude := \
+    src/deprecated.h
+```
+
+### Q: How do I conditionally compile based on available dependencies?
+
+```makefile
+ifdef cuda.dir
+    mylib.lib.extern += cuda
+else
+    mylib.lib.sources.exclude += gpu_solver.cu
+endif
+```
+
+## Testing
+
+### Q: How do I run tests?
+
+```bash
+mm test                  # Run all tests
+mm test.mylib            # Run specific test suite
+```
+
+### Q: How do I set up tests?
+
+For implicit tests (each source file is a test driver):
+```makefile
+myproject.tests := mylib.tests
+
+mylib.tests.stem := mylib.tests
+mylib.tests.extern := mylib.lib
+mylib.tests.prerequisites := mylib.lib
+```
+
+For explicit test cases:
+```makefile
+tests.myapp.driver.cases := case1 case2 case3
+case1.argv := --input test1.dat
+case2.argv := --input test2.dat --verbose
+```
+
+## Advanced
+
+### Q: How do I integrate with environment modules?
+
+Create a modulefile:
+```lua
+setenv("mm_prefix", "/opt/myproject/gcc/opt")
+setenv("mm_targets", "opt,shared")
+prepend_path("PATH", pathJoin(os.getenv("mm_prefix"), "bin"))
+prepend_path("PYTHONPATH", pathJoin(os.getenv("mm_prefix"), "packages"))
+```
+
+Or use mm's built-in support:
+```bash
+eval $(mm --paths=sh)      # Inject build env into shell
+```
+
+### Q: Can I use mm with Docker?
+
+Yes, mm has docker-images support:
+```makefile
+myproject.docker-images := myapp.focal myapp.jammy
+
+myapp.focal.name := focal-gcc-mm
+myapp.jammy.name := jammy-gcc-mm
+```
+
+### Q: How do I build for multiple compilers/targets?
+
+Use environment variables or modules:
+```bash
+# GCC debug
+export mm_compiler=gcc mm_targets=debug
+mm
+
+# Clang optimized  
+export mm_compiler=clang++ mm_targets=opt,shared
+mm
+```
+
+Each combination gets its own build directory.
+
+### Q: Can I override prefix and bldroot per invocation?
+
+Yes:
+```bash
+mm --prefix=/tmp/test --bldroot=/tmp/build
+```
+
+Or via environment:
+```bash
+export mm_prefix=/tmp/test
+export mm_bldroot=/tmp/build
+mm
+```
+
+## Troubleshooting
+
+### Q: mm says "GNU Make 4.2.1 or higher required"
+
+Your make is too old. Install a newer version:
+```bash
+# Ubuntu/Debian
+sudo apt install make
+
+# Or install from source
+wget https://ftp.gnu.org/gnu/make/make-4.4.tar.gz
+```
+
+### Q: mm can't find my project configuration
+
+Make sure:
+1. You have a `.mm/` directory in your project root
+2. The file is named `.mm/{project}.mm` 
+3. You're running mm from within the project tree
+
+mm walks up from the current directory looking for `.mm/`.
+
+### Q: My library isn't linking against dependencies
+
+Make sure you specified `extern`:
+```makefile
+mylib.lib.extern := cuda mpi hdf5
+```
+
+Check that the dependencies are configured in `~/.mm/config.mm`.
+
+### Q: Headers aren't being installed
+
+By default, all `.h` files in `{library}.root` are installed.
+
+If they're not, check:
+1. Are they in subdirectories? Specify `{library}.directories`
+2. Are they in `{library}.headers.exclude`?
+
+### Q: Python package isn't importing
+
+Check:
+1. Is `products/packages/` in your `PYTHONPATH`?
+2. Run: `eval $(mm --paths=sh)` to set up environment
+3. Is the package actually installed? Check `products/packages/`
+
+## Philosophy
+
+### Q: Why not CMake/Autotools/SCons?
+
+mm is **opinionated** and **convention-based**:
+- No hand-written makefiles or CMakeLists.txt
+- Auto-discovers sources (convention over configuration)
+- Pre-configured for common dependencies
+- Designed for scientific computing workflows
+
+It trades flexibility for simplicity and speed.
+
+### Q: When should I NOT use mm?
+
+If you need:
+- Windows native builds (mm is Unix/Linux focused)
+- Non-standard project layouts mm doesn't support
+- Build systems that are part of your API (e.g., header-only libraries with CMake configs)
+- Complete control over every compiler flag for every file
+
+### Q: Can I see the generated makefiles?
+
+mm doesn't generate makefiles. It uses a library of makefile fragments in `{mm}/make/`.
+
+To see what make does: `mm --verbose`
+
+## Getting Help
+
+### Q: Where can I find more examples?
+
+- `examples/hello/` - Comprehensive multi-language project
+- `examples/simple/` - Minimal examples
+- `examples/prep/` - Test dependency examples
+
+### Q: How do I report bugs or request features?
+
+Open an issue at the [mm repository on GitHub](https://github.com/aivazis/mm).
+
+### Q: Is there a community/mailing list?
+
+See the [mm repository on GitHub](https://github.com/aivazis/mm) for discussions and contributions.

--- a/docs/command-line-reference.md
+++ b/docs/command-line-reference.md
@@ -1,0 +1,495 @@
+# mm Command-Line Reference
+
+Complete reference for all mm command-line options and environment variables.
+
+## Basic Usage
+
+```bash
+mm [options] [make-targets...]
+```
+
+Everything after mm options is passed directly to GNU Make.
+
+## Quick Reference
+
+### Most Common Options
+
+```bash
+mm                          # Build with defaults (debug, shared)
+mm --target=opt             # Optimized build
+mm --prefix=/opt/myproject  # Install to custom location
+mm --verbose                # See all compiler commands
+mm --show                   # Show make invocation
+mm --paths=sh               # Export build environment
+mm test                     # Run all tests
+```
+
+## Build Configuration Options
+
+### `--project=<name>`
+
+Set the project name. Normally this is set in your `.mm/{project}.mm` file.
+
+**Type:** String  
+**Default:** Inferred from directory name  
+**Example:**
+```bash
+mm --project=myproject
+```
+
+### `--prefix=<path>`
+
+Install location for build products.
+
+**Type:** Path  
+**Default:** `{project-root}/products`  
+**Environment:** `mm_prefix`  
+**Example:**
+```bash
+mm --prefix=/opt/myproject
+mm --prefix=$HOME/local
+```
+
+Products installed to:
+- `{prefix}/bin/` - Executables
+- `{prefix}/lib/` - Libraries
+- `{prefix}/include/` - Headers
+- `{prefix}/packages/` - Python packages
+
+### `--bldroot=<path>`
+
+Location for intermediate build files (`.o`, `.d`, etc.).
+
+**Type:** Path  
+**Default:** `{project-root}/builds`  
+**Environment:** `mm_bldroot`  
+**Example:**
+```bash
+mm --bldroot=/tmp/builds
+mm --bldroot=$HOME/tmp/myproject
+```
+
+### `--target=<variants>`
+
+Build target variants (comma-separated).
+
+**Type:** List of strings  
+**Default:** `debug,shared`  
+**Environment:** `mm_targets`  
+**Available targets:**
+- `debug` - Debug symbols, no optimization
+- `opt` - Optimized (`-O3`)
+- `shared` - Shared libraries (`.so`)
+- ~~`static`~~ - **Not a built-in variant.** To build static-only, omit `shared` from `--target`.
+- `prof` - Profiling enabled (`-pg`)
+- `cov` - Coverage enabled (`--coverage`)
+- `reldeb` - Release with debug info
+
+**Examples:**
+```bash
+mm --target=opt              # Optimized only
+mm --target=debug,shared     # Debug + shared (default)
+mm --target=opt              # Optimized, static (no shared)
+mm --target=opt,shared       # Optimized + shared
+mm --target=prof,shared      # Profiling + shared
+```
+
+Each target combination gets its own directory: `builds/{variants}-{platform}-{arch}/`
+
+## Build Behavior Options
+
+### `--show`
+
+Display the full make command that mm will invoke.
+
+**Type:** Boolean  
+**Default:** `false`  
+**Example:**
+```bash
+mm --show
+# Output: make: gmake --warn-undefined-variables --silent -j 16 ...
+```
+
+### `--dry`
+
+Do everything except actually invoke make (dry run).
+
+**Type:** Boolean  
+**Default:** `false`  
+**Example:**
+```bash
+mm --dry --show    # See what would be run
+```
+
+### `--verbose`
+
+Show every command make executes (compiler invocations, etc.).
+
+**Type:** Boolean  
+**Default:** `false`  
+**Example:**
+```bash
+mm --verbose
+# Output shows:
+# g++ -std=c++17 -O3 -c src/main.cc -o builds/.../main.o
+# g++ -shared builds/.../main.o -o products/lib/libmylib.so
+```
+
+**Note:** Automatically forces `--serial` for readable output.
+
+### `--quiet`
+
+Suppress all non-critical output.
+
+**Type:** Boolean  
+**Default:** `false`  
+**Example:**
+```bash
+mm --quiet    # Silent unless errors occur
+```
+
+### `--ignore`
+
+Continue building even if some targets fail.
+
+**Type:** Boolean  
+**Default:** `false`  
+**Example:**
+```bash
+mm --ignore    # Keep going despite failures
+```
+
+## Parallelism Options
+
+### `--serial`
+
+Build serially (one recipe at a time).
+
+**Type:** Boolean  
+**Default:** `false`  
+**Example:**
+```bash
+mm --serial          # Single-threaded
+mm --serial --verbose  # For debugging (clean output)
+```
+
+### `--slots=<N>`
+
+Number of recipes to execute simultaneously.
+
+**Type:** Integer  
+**Default:** Number of CPU cores  
+**Example:**
+```bash
+mm --slots=8     # Use 8 cores
+mm --slots=1     # Same as --serial
+mm -j 16         # Can also use make's -j syntax
+```
+
+## Advanced Options
+
+### `--compilers=<list>`
+
+Override the default compiler set.
+
+**Type:** List of strings  
+**Default:** System-dependent  
+**Environment:** `mm_compilers`  
+**Example:**
+```bash
+mm --compilers=gcc
+mm --compilers="clang++,gfortran"
+```
+
+### `--make=<command>`
+
+GNU make executable to use.
+
+**Type:** String  
+**Default:** `gmake` (or `$GNU_MAKE`)  
+**Example:**
+```bash
+mm --make=make
+mm --make=/usr/local/bin/gmake
+```
+
+### `--runcfg=<path>`
+
+Additional directory to add to make's include path.
+
+**Type:** String  
+**Default:** Empty  
+**Example:**
+```bash
+mm --runcfg=/path/to/extra/config
+```
+
+### `--cfgdir=<name>`
+
+Name of project configuration directory.
+
+**Type:** String  
+**Default:** `.mm`  
+**Example:**
+```bash
+mm --cfgdir=.build-config
+```
+
+### `--local=<filename>`
+
+Name of local makefile to search for.
+
+**Type:** String  
+**Default:** `Make.mm`  
+**Example:**
+```bash
+mm --local=Makefile
+```
+
+## Make Debug Options
+
+### `--ruledb`
+
+Ask make to print its rule database.
+
+**Type:** Boolean  
+**Default:** `false`  
+**Example:**
+```bash
+mm --ruledb > rules.txt    # See all make rules
+```
+
+### `--trace`
+
+Ask make to print trace information.
+
+**Type:** Boolean  
+**Default:** `false`  
+**Example:**
+```bash
+mm --trace    # See make's decision process
+```
+
+## Environment Export Options
+
+### `--paths=<shell>`
+
+Generate shell commands to export build environment.
+
+**Type:** String (one of: `sh`, `csh`, `fish`)  
+**Default:** None  
+**Example:**
+```bash
+# Bash/sh
+eval $(mm --paths=sh)
+
+# Csh/tcsh
+eval `mm --paths=csh`
+
+# Fish
+eval (mm --paths=fish)
+```
+
+**What it sets:**
+- `PATH` - Adds `{prefix}/bin`
+- `PYTHONPATH` - Adds `{prefix}/packages`
+- `MM_INCLUDES` - Sets to `{prefix}/include`
+- `MM_LIBPATH` - Sets to `{prefix}/lib`
+
+**Use cases:**
+- Running binaries built by mm
+- Importing Python packages built by mm
+- Linking against libraries built by mm
+
+### `--clear`
+
+Remove mm paths from environment (used with `--paths`).
+
+**Type:** Boolean  
+**Default:** `false`  
+**Example:**
+```bash
+eval $(mm --paths=sh --clear)    # Remove mm from environment
+```
+
+## Display Options
+
+### `--color`
+
+Enable colorized output on supported terminals.
+
+**Type:** Boolean  
+**Default:** `true`  
+**Example:**
+```bash
+mm --color=no     # Disable colors
+mm --color=yes    # Enable colors (default)
+```
+
+### `--palette=<name>`
+
+Color palette to use.
+
+**Type:** String  
+**Default:** `builtin`  
+**Example:**
+```bash
+mm --palette=builtin    # Default palette
+```
+
+## Setup Options
+
+### `--setup`
+
+Initialize user configuration directory (`~/.mm/`).
+
+**Type:** Boolean  
+**Default:** `false`  
+**Example:**
+```bash
+mm --setup    # Creates ~/.mm/config.mm with templates
+```
+
+Creates `~/.mm/config.mm` with commented-out configuration for common external packages.
+
+## Environment Variables
+
+mm can read configuration from environment variables. Command-line options override environment variables.
+
+### Build Configuration
+
+```bash
+export mm_prefix="/opt/myproject"       # Install location
+export mm_bldroot="/tmp/builds"         # Build staging area
+export mm_targets="opt,shared"          # Build targets
+export mm_compiler="gcc"                # Compiler choice
+export mm_compilers="gcc,gfortran"      # Compiler set
+```
+
+### System Variables
+
+```bash
+export GNU_MAKE="gmake"                 # Make executable
+export MPI_HOME="/usr/lib/openmpi"      # MPI location (used in configs)
+```
+
+### Module System Integration
+
+For environment modules (Lmod, etc.):
+
+```lua
+-- myproject.lua
+setenv("mm_system", "mm")
+setenv("mm_abi", "opt-shared-linux-x86_64")
+setenv("mm_target", "opt")
+setenv("mm_compiler", "gcc")
+setenv("mm_prefix", "/opt/myproject/gcc/opt")
+setenv("mm_bldroot", "/tmp/builds/myproject")
+setenv("mm_targets", "opt,shared")
+
+prepend_path("PATH", "/opt/myproject/gcc/opt/bin")
+prepend_path("PYTHONPATH", "/opt/myproject/gcc/opt/packages")
+prepend_path("LD_LIBRARY_PATH", "/opt/myproject/gcc/opt/lib")
+```
+
+## Passing Arguments to Make
+
+Everything after mm options is passed to make:
+
+```bash
+mm clean                    # Run 'make clean'
+mm test                     # Run 'make test'
+mm test.mylib              # Run specific test suite
+mm install                 # Run 'make install'
+mm -n                      # Make dry-run (show commands)
+mm VERBOSE=1               # Set make variable
+mm --target=opt clean all  # Clean then build with opt target
+```
+
+## Common Workflows
+
+### Clean Build
+
+```bash
+rm -rf builds products
+mm
+```
+
+### Debug Build
+
+```bash
+mm --target=debug --verbose --serial
+```
+
+### Optimized Release
+
+```bash
+mm --target=opt --prefix=/opt/myproject
+```
+
+### CI/CD Build
+
+```bash
+#!/bin/bash
+export mm_prefix="/tmp/install"
+export mm_bldroot="/tmp/build"
+export mm_targets="opt"
+
+mm clean
+mm
+mm test
+```
+
+### Multi-Compiler Build
+
+```bash
+# GCC debug
+export mm_compiler=gcc
+mm --target=debug --prefix=$HOME/gcc-debug
+
+# Clang optimized
+export mm_compiler=clang++
+mm --target=opt --prefix=$HOME/clang-opt
+```
+
+### Development Workflow
+
+```bash
+# Initial build
+mm
+
+# Set up environment
+eval $(mm --paths=sh)
+
+# Use build products
+python -c "import mypackage"
+./products/bin/myapp
+
+# Rebuild
+mm
+
+# Run tests
+mm test
+
+# Clean up environment when done
+eval $(mm --paths=sh --clear)
+```
+
+## Runtime Target Help
+
+mm provides built-in help through make targets:
+
+```bash
+mm --help                  # Show all command-line options
+mm <project>.help          # List available targets for a project
+mm <project>.info          # Show project configuration details
+mm <asset>.info            # Show configuration for a library, package, etc.
+mm builder.info.help       # List all info targets
+mm host.info               # Show host platform details
+```
+
+## See Also
+
+- [Quickstart Guide](quickstart.md) - Get building in 5 minutes
+- [FAQ](FAQ.md) - Common questions and troubleshooting
+- [Examples](examples.md) - Walkthrough of example projects

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,439 @@
+# mm Examples Walkthrough
+
+This guide provides an in-depth tour of mm's example projects, showing real-world usage patterns.
+
+## The Hello Example: A Complete Multi-Language Project
+
+The `examples/hello/` project demonstrates mm's full capabilities in a single, well-organized example.
+
+### Project Structure
+
+```
+examples/hello/
+├── .mm/
+│   └── hello.mm          # Project configuration
+├── lib/hello/            # C++ library sources
+│   ├── hello.h           # Main header
+│   ├── greetings/        # Greetings subsystem
+│   │   ├── hello.h
+│   │   ├── hello.cc      # C++ implementation
+│   │   ├── goodbye.h
+│   │   └── goodbye.cc
+│   └── friends/          # Multi-language implementations
+│       ├── alec.h, alec.cc     # C++
+│       ├── ally.h, ally.cc     # C++
+│       ├── mac.h, mac.c        # C
+│       └── mat.h, mat.f03      # Fortran
+├── pkg/hello/            # Python package
+│   ├── __init__.py
+│   ├── cli/              # Command-line interface
+│   └── shells/           # Application shells
+├── ext/hello/            # Python C++ extension
+│   ├── hello.cc          # Main module
+│   ├── greetings.cc      # Bindings for greetings
+│   └── friends.cc        # Bindings for friends
+├── bin/
+│   └── say               # Executable driver script
+├── tests/
+│   ├── hello.lib/        # C++ library tests
+│   │   ├── say-hello.cc
+│   │   └── say-goodbye.cc
+│   └── hello.pkg/        # Python package tests
+│       ├── sanity.py
+│       └── say.py
+└── etc/
+    └── bash_completions/ # Shell completions
+```
+
+### What This Project Builds
+
+From this single directory structure, mm produces:
+
+1. **C++ Library**: `libhello.so`
+   - Links against: `pyre`
+   - Compiled from: all `.cc`, `.c`, `.f03` files in `lib/hello/`
+   - Installs to: `products/lib/libhello.so`
+
+2. **Headers**: Complete directory structure preserved
+   - Installs to: `products/include/hello/`
+   - All `.h` files, preserving subdirectories
+
+3. **Python Package**: `hello`
+   - All `.py` files from `pkg/hello/`
+   - Installs to: `products/packages/hello/`
+
+4. **Python Extension**: `hello.so`
+   - C++ extension wrapping `libhello`
+   - Installs to: `products/packages/hello/hello.so`
+   - Importable as: `from hello import hello`
+
+5. **Executable**: `say`
+   - Command-line tool
+   - Installs to: `products/bin/say`
+
+6. **Test Suites**:
+   - C++ tests: `test.hello.lib.*`
+   - Python tests: `test.hello.pkg.*`
+
+### Building the Example
+
+```bash
+cd examples/hello
+
+# Build everything (uses all CPU cores by default)
+mm
+
+# Output shows:
+# Compiling: lib/hello/greetings/hello.cc
+# Compiling: lib/hello/greetings/goodbye.cc
+# Compiling: lib/hello/friends/alec.cc (C++)
+# Compiling: lib/hello/friends/ally.cc (C++)
+# Compiling: lib/hello/friends/mac.c (C)
+# Compiling: lib/hello/friends/mat.f03 (Fortran)
+# Linking: products/lib/libhello.so
+# Installing: Python package hello
+# Compiling: ext/hello/hello.cc
+# Linking: products/packages/hello/hello.so
+# Installing: products/bin/say
+```
+
+### Using the Build Products
+
+```bash
+# Set up environment to use the products
+eval $(mm --paths=sh)
+
+# Use the command-line tool
+say hello alec
+# Output: Hello, Alec!
+
+say goodbye mat
+# Output: Goodbye, Matthias!
+
+# Use from Python
+python << EOF
+import hello
+print(hello.greet())  # Uses C++ extension
+EOF
+# Output: hello
+
+# Check what was built
+ls products/lib/         # libhello.so
+ls products/include/     # hello/ directory tree
+ls products/packages/    # hello/ Python package
+ls products/bin/         # say executable
+```
+
+### Running Tests
+
+```bash
+# Run all tests
+mm test
+
+# Run specific test suites
+mm test.hello.lib        # C++ library tests only
+mm test.hello.pkg        # Python package tests only
+
+# Run specific test cases
+mm test.hello.lib.say-hello
+mm test.hello.pkg.say.hello.alec
+```
+
+### Key Configuration Patterns
+
+Let's break down the `.mm/hello.mm` configuration (which is now heavily annotated):
+
+#### 1. Multi-Language Library
+
+```makefile
+# Declare the library
+hello.libraries := hello.lib
+
+# Configure it
+hello.lib.stem := hello
+hello.lib.extern := pyre
+hello.lib.c++.flags += $($(compiler.c++).std.c++17)
+```
+
+**What happens:**
+- mm scans `lib/hello/` for ALL source files
+- Finds: `.cc` (C++), `.c` (C), `.f03` (Fortran)
+- Compiles each with appropriate compiler
+- Links into single `libhello.so`
+- Installs all `.h` files preserving structure
+
+#### 2. Python Package with Drivers
+
+```makefile
+# Declare the package
+hello.packages := hello.pkg
+
+# Configure it
+hello.pkg.stem := hello
+hello.pkg.drivers := say
+```
+
+**What happens:**
+- mm copies all `.py` files from `pkg/hello/` to `products/packages/hello/`
+- Finds `bin/say` and installs to `products/bin/say` (executable)
+- Package is importable via `PYTHONPATH`
+
+#### 3. Python Extension Wrapping C++
+
+```makefile
+# Declare the extension
+hello.extensions := hello.ext
+
+# Configure it
+hello.ext.stem := hello
+hello.ext.pkg := hello.pkg          # Install INTO this package
+hello.ext.wraps := hello.lib        # Link AGAINST this library
+hello.ext.extern := hello.lib pyre python
+```
+
+**What happens:**
+- mm compiles extension sources from `ext/hello/`
+- Links against `libhello.so` and Python libraries
+- Installs to `products/packages/hello/hello.so`
+- Python can import: `from hello import hello` (the extension module)
+
+#### 4. Implicit Test Discovery
+
+```makefile
+# C++ tests
+hello.tests.hello.lib.stem := hello.lib
+hello.tests.hello.lib.extern := hello.lib pyre
+hello.tests.hello.lib.prerequisites := hello.lib
+```
+
+**What happens:**
+- mm finds ALL `.cc` files in `tests/hello.lib/`
+- Compiles each as standalone test executable
+- Runs each executable
+- Exit code 0 = pass, non-zero = fail
+
+No explicit test case list needed!
+
+#### 5. Explicit Test Cases
+
+```makefile
+# Python tests with arguments
+tests.hello.pkg.say.cases := say.hello.alec say.hello.mac
+
+say.hello.alec.argv := hello alec
+say.hello.mac.argv := hello mac
+```
+
+**What happens:**
+- mm runs: `python tests/hello.pkg/say.py hello alec`
+- mm runs: `python tests/hello.pkg/say.py hello mac`
+- Captures output and checks exit codes
+
+### Auto-Discovery in Action
+
+The power of mm is that **most of the configuration** is implicit:
+
+#### Library Discovery
+```makefile
+hello.lib.stem := hello
+# Implicitly:
+# hello.lib.root := lib/hello/
+# hello.lib.directories := <all subdirs recursively>
+# hello.lib.sources := <all .cc, .c, .f files>
+# hello.lib.headers := <all .h files>
+```
+
+#### Package Discovery
+```makefile
+hello.pkg.stem := hello
+# Implicitly:
+# hello.pkg.root := pkg/hello/
+# Copies entire directory tree to products/packages/hello/
+```
+
+#### Test Discovery
+```makefile
+hello.tests.hello.lib.stem := hello.lib
+# Implicitly:
+# Finds ALL .cc files in tests/hello.lib/
+# Each becomes a test case
+```
+
+### Conditional Compilation Example
+
+While not used in hello, here's how you'd add conditional features:
+
+```makefile
+# In .mm/hello.mm, add:
+ifdef cuda.dir
+    hello.lib.extern += cuda
+    hello.lib.cuda.flags += -allow-unsupported-compiler
+else
+    # Exclude GPU implementations
+    hello.lib.sources.exclude += lib/hello/gpu/gpu_greet.cu
+endif
+
+ifdef hdf5.dir
+    hello.lib.extern += hdf5
+else
+    hello.lib.sources.exclude += lib/hello/io/hdf5_writer.cc
+endif
+```
+
+This enables features based on what's available in `~/.mm/config.mm`.
+
+## Other Examples
+
+### examples/simple/
+
+Minimal examples showing basic patterns. Good for:
+- Quick reference
+- Copy-paste starting points
+- Understanding minimal configuration
+
+### examples/prep/
+
+Test dependency examples showing how projects declare test prerequisites.
+
+## Building Your Own Project Based on Hello
+
+### Step 1: Copy the Structure
+
+```bash
+# Start with hello's layout
+mkdir myproject
+cd myproject
+mkdir -p .mm lib/mylib pkg/mypkg ext/myext tests/mylib.lib tests/mypkg.pkg bin
+
+# Copy and adapt the configuration
+cp examples/hello/.mm/hello.mm .mm/myproject.mm
+```
+
+### Step 2: Adapt the Configuration
+
+Edit `.mm/myproject.mm`:
+
+```makefile
+# -*- Makefile -*-
+
+# Declare what you're building
+myproject.libraries := mylib.lib
+myproject.packages := mypkg.pkg
+myproject.extensions := myext.ext
+
+# Library
+mylib.lib.stem := mylib
+mylib.lib.extern := pyre          # Your dependencies here
+mylib.lib.c++.flags := $($(compiler.c++).std.c++20)
+
+# Package
+mypkg.pkg.stem := mypkg
+mypkg.pkg.drivers := myapp
+
+# Extension
+myext.ext.stem := myext
+myext.ext.pkg := mypkg.pkg
+myext.ext.wraps := mylib.lib
+myext.ext.extern := mylib.lib pyre python
+```
+
+### Step 3: Add Your Code
+
+```bash
+# Add library sources
+cat > lib/mylib/mylib.h << 'EOF'
+#pragma once
+const char* greet();
+EOF
+
+cat > lib/mylib/mylib.cc << 'EOF'
+#include "mylib.h"
+const char* greet() { return "Hello from mylib!"; }
+EOF
+
+# Add Python code
+cat > pkg/mypkg/__init__.py << 'EOF'
+def hello():
+    print("Hello from Python!")
+EOF
+```
+
+### Step 4: Build
+
+```bash
+mm
+```
+
+That's it!
+
+## Tips for Large Projects
+
+### 1. Organize by Subsystem
+
+```
+lib/mylib/
+  core/           # Core functionality
+  geometry/       # Geometry subsystem
+  physics/        # Physics subsystem
+  io/             # I/O subsystem
+```
+
+mm automatically discovers everything.
+
+### 2. Use Separate Config Files
+
+For very large projects, split configuration:
+
+```makefile
+# .mm/myproject.mm
+include libmylib.dirs
+include libmylib.exclusions
+include libmylib.tests
+
+mylib.lib.directories := \
+    ${addprefix $(mylib.lib.root),$(libmylib.srcdirs)}
+```
+
+See `sumMIT` project for real-world example of this pattern.
+
+### 3. Separate Build Variants
+
+```bash
+# Debug build
+mm --target=debug
+
+# Optimized build
+mm --target=opt
+
+# Profiling build
+mm --target=prof
+```
+
+Each gets its own directory in `builds/`.
+
+### 4. Document Your Configuration
+
+Add comments explaining non-obvious choices:
+
+```makefile
+# Link against MPI for parallel operations
+mylib.lib.extern += mpi
+
+# Disable AVX on older machines
+# mylib.lib.c++.flags += -mno-avx
+```
+
+## Summary
+
+The hello example shows that with mm, you can:
+
+1. **Build complex multi-language projects** with minimal configuration
+2. **Let directory structure** drive the build
+3. **Auto-discover** sources, tests, and dependencies
+4. **Mix languages** seamlessly (C, C++, Fortran in same library)
+5. **Create Python extensions** with simple declarations
+6. **Test everything** with implicit + explicit test discovery
+
+The key insight: **mm doesn't need explicit file lists**. Organize your code well, declare what you're building, and let mm handle the details.
+
+See `examples/hello/.mm/hello.mm` for the complete configuration.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,483 @@
+# mm Quickstart Guide
+
+Get from zero to a working build in 5 minutes.
+
+## What is mm?
+
+**mm** is an opinionated build framework that combines:
+- **Python** for intelligent project discovery and configuration
+- **GNU Make** for parallel, dependency-driven compilation
+
+Key features:
+- **Zero boilerplate**: No makefiles needed, just declare what you're building
+- **Auto-discovery**: Finds sources automatically based on directory structure
+- **Multi-language**: C, C++, Fortran, CUDA, Python, Cython, JavaScript
+- **Smart dependencies**: Handles external packages (MPI, CUDA, HDF5, etc.)
+- **Parallel by default**: Uses all CPU cores automatically
+
+## Installation
+
+```bash
+# Clone or download mm
+cd /path/to/mm
+
+# Install to your preferred location
+./install.sh ~/.local          # User install
+# or
+./install.sh /usr/local        # System-wide (needs sudo)
+
+# Add to PATH if using ~/.local
+export PATH="$HOME/.local/bin:$PATH"
+
+# Verify installation
+mm --help
+```
+
+## Quick Start: Build a C++ Library
+
+### 1. Create Project Structure
+
+```bash
+mkdir myproject && cd myproject
+
+# Create the magic directory
+mkdir .mm
+
+# Create source directory
+mkdir -p lib/mylib
+```
+
+### 2. Write Some Code
+
+```bash
+# lib/mylib/hello.h
+cat > lib/mylib/hello.h << 'EOF'
+#pragma once
+const char* greet();
+EOF
+
+# lib/mylib/hello.cc
+cat > lib/mylib/hello.cc << 'EOF'
+#include "hello.h"
+const char* greet() { return "Hello from mm!"; }
+EOF
+
+# lib/mylib/main.cc
+cat > lib/mylib/main.cc << 'EOF'
+#include "hello.h"
+#include <iostream>
+int main() {
+    std::cout << greet() << std::endl;
+    return 0;
+}
+EOF
+```
+
+### 3. Configure the Build
+
+This is the **only** configuration file you need:
+
+```bash
+# .mm/myproject.mm
+cat > .mm/myproject.mm << 'EOF'
+# -*- Makefile -*-
+
+# Declare we're building a library
+myproject.libraries := mylib.lib
+
+# Library configuration
+mylib.lib.stem := mylib
+mylib.lib.root := lib/mylib/
+
+# C++ standard
+mylib.lib.c++.flags := $($(compiler.c++).std.c++17)
+EOF
+```
+
+### 4. Build!
+
+```bash
+mm
+```
+
+That's it! mm will:
+- Find all `.cc` and `.h` files in `lib/mylib/`
+- Compile them in parallel
+- Create a shared library: `products/lib/libmylib.so`
+- Install headers to: `products/include/mylib/`
+
+### Output Structure
+
+```
+myproject/
+├── .mm/
+│   └── myproject.mm          # Your only config file
+├── lib/mylib/                # Source code
+│   ├── hello.h
+│   ├── hello.cc
+│   └── main.cc
+├── builds/                   # Intermediate build products (auto-created)
+│   └── debug-shared-linux-x86_64/
+│       └── mylib.lib/
+│           ├── hello.o
+│           └── ...
+└── products/                 # Final build products (auto-created)
+    ├── bin/
+    ├── include/mylib/
+    │   └── hello.h
+    └── lib/
+        └── libmylib.so
+```
+
+## Understanding Auto-Discovery
+
+**mm doesn't need explicit source lists**. It discovers files based on:
+
+### Simple Case: Single Directory
+
+```makefile
+mylib.lib.root := lib/mylib/
+```
+
+mm automatically finds **all** `.cc`, `.c`, `.f`, `.cu` files in that directory.
+
+### Multiple Directories
+
+For large projects, specify which directories to scan:
+
+```makefile
+mylib.lib.root := src/
+mylib.lib.directories := \
+    ./ \
+    geometry/ \
+    physics/ \
+    io/
+```
+
+This tells mm to look in:
+- `src/`
+- `src/geometry/`
+- `src/physics/`
+- `src/io/`
+
+### Excluding Files
+
+Sometimes you need to exclude specific files:
+
+```makefile
+mylib.lib.sources.exclude := \
+    src/old_code.cc \
+    src/experimental/prototype.cc
+
+mylib.lib.headers.exclude := \
+    src/deprecated.h
+```
+
+### Advanced: Conditional Compilation
+
+Enable/disable features based on available dependencies:
+
+```makefile
+# .mm/libsummit.dirs (in a separate file for clarity)
+define libsummit.srcdirs :=
+    ./
+    fem/
+    solvers/
+    io/
+endef
+
+# .mm/myproject.mm
+include libsummit.dirs
+
+mylib.lib.directories := ${addprefix $(mylib.lib.root),$(libsummit.srcdirs)}
+
+# Conditional compilation based on availability
+ifdef cuda.dir
+    mylib.lib.extern += cuda
+else
+    mylib.lib.sources.exclude += solvers/gpu_solver.cu
+endif
+
+ifdef hdf5.dir
+    mylib.lib.extern += hdf5
+else
+    mylib.lib.sources.exclude += io/hdf5_writer.cc
+endif
+```
+
+## Building Python Packages
+
+```bash
+mkdir -p pkg/myapp
+cat > .mm/myproject.mm << 'EOF'
+# -*- Makefile -*-
+
+myproject.packages := myapp.pkg
+
+myapp.pkg.stem := myapp
+myapp.pkg.root := pkg/myapp/
+EOF
+
+# Create Python code
+cat > pkg/myapp/__init__.py << 'EOF'
+def hello():
+    return "Hello from Python!"
+EOF
+
+mm
+```
+
+Installs to: `products/packages/myapp/`
+
+## Building Python Extensions (C++/Python bindings)
+
+```bash
+mkdir -p ext/myext
+cat > .mm/myproject.mm << 'EOF'
+# -*- Makefile -*-
+
+myproject.libraries := mylib.lib
+myproject.packages := myapp.pkg
+myproject.extensions := myext.ext
+
+# Extension wraps the C++ library
+myext.ext.stem := myext
+myext.ext.root := ext/myext/
+myext.ext.pkg := myapp.pkg          # Install into this package
+myext.ext.wraps := mylib.lib        # Links against this library
+myext.ext.extern := mylib.lib python
+EOF
+```
+
+## External Dependencies
+
+mm has pre-configured support for 20+ libraries:
+
+```makefile
+# Link against external libraries
+mylib.lib.extern := mpi cuda hdf5 gsl petsc
+
+# If they're in standard locations, mm finds them
+# Otherwise configure in ~/.mm/config.mm:
+#
+# cuda.dir := /usr/local/cuda
+# cuda.incpath := $(cuda.dir)/include
+# cuda.libpath := $(cuda.dir)/lib64
+```
+
+Supported packages: `mpi`, `cuda`, `hdf5`, `vtk`, `petsc`, `slepc`, `gsl`, `fftw`, `metis`, `parmetis`, `pyre`, `python`, `numpy`, `gtest`, `gmsh`, `gdal`, `libpq`, and more.
+
+## Build Targets
+
+mm supports multiple build configurations:
+
+```bash
+mm                          # Default: debug + shared
+mm --target=opt             # Optimized build
+mm --target=opt,shared      # Optimized + shared libraries
+mm --target=prof            # With profiling
+mm --target=cov             # With coverage
+
+# Parallel control
+mm -j 8                     # Use 8 cores
+mm --serial                 # Single-threaded (for debugging)
+```
+
+## Common Tasks
+
+### Clean builds
+```bash
+rm -rf builds products
+mm
+```
+
+### Install elsewhere
+```bash
+mm --prefix=/opt/myproject
+```
+
+### Verbose output
+```bash
+mm --verbose                # See all compiler commands
+mm --show                   # Show make invocation
+```
+
+### Just tests
+```bash
+mm test                     # Run all tests
+mm test.mylib               # Run specific test suite
+```
+
+## Configuration Hierarchy
+
+mm searches for configuration in this order:
+1. Command-line arguments (`--prefix`, `--bldroot`, `--target`)
+2. Environment variables (`mm_prefix`, `mm_bldroot`, `mm_targets`)
+3. User configuration files (in `~/.mm/`)
+4. Project configuration (in `.mm/`)
+
+### User Configuration
+
+Set up external dependencies once:
+
+```bash
+mm --setup                  # Creates ~/.mm/config.mm
+
+# Edit ~/.mm/config.mm - applies to ALL projects
+cat >> ~/.mm/config.mm << 'EOF'
+# CUDA
+cuda.dir := /usr/local/cuda-12.0
+cuda.incpath := $(cuda.dir)/include
+cuda.libpath := $(cuda.dir)/lib64
+
+# HDF5
+hdf5.dir := /opt/hdf5
+hdf5.incpath := $(hdf5.dir)/include
+hdf5.libpath := $(hdf5.dir)/lib
+EOF
+```
+
+### Host-Specific Configuration
+
+mm automatically loads `~/.mm/{user}@{hostname}.mm` for machine-specific settings:
+
+```bash
+# ~/.mm/rapa@laptop.mm
+cat > ~/.mm/rapa@laptop.mm << 'EOF'
+# -*- Makefile -*-
+
+# System paths
+sys.prefix := /usr
+sys.opt.prefix := /opt/apps
+
+# MPI (using module-provided path)
+mpi.version := 4.1.4
+mpi.flavor := openmpi
+mpi.dir := $(MPI_HOME)
+mpi.executive := mpirun
+
+# PETSc with MPI
+petsc.dir := $(sys.prefix)
+petsc.incpath := $(petsc.dir)/include/openmpi-x86_64/petsc
+petsc.libpath := $(petsc.dir)/lib64/openmpi/lib
+
+# CUDA
+cuda.dir := /usr/local/cuda
+cuda.incpath := $(cuda.dir)/include
+cuda.libpath := $(cuda.dir)/lib64
+
+# Python
+python.version := 3.9
+python.dir := $(sys.prefix)
+python.incpath := $(python.dir)/include/python$(python.version)
+
+# GSL, Eigen, etc. in standard locations
+gsl.dir := $(sys.prefix)
+eigen.dir := $(sys.prefix)
+pyre.dir := $(sys.opt.prefix)/pyre
+EOF
+```
+
+This way, each developer/machine has its own configuration without affecting the project.
+
+## Environment Variables
+
+mm supports environment variables for CI/CD and module systems:
+
+```bash
+# Set build configuration
+export mm_targets="opt,shared"          # Build targets (comma-separated)
+export mm_compiler="gcc"                # Compiler choice
+export mm_prefix="/opt/myproject"       # Install location
+export mm_bldroot="/tmp/builds"         # Build staging area
+
+# Build with these settings
+mm
+```
+
+### Using with Environment Modules
+
+Create a module file for your build products:
+
+```lua
+-- myproject/gcc-opt.lua
+setenv("mm_system", "mm")
+setenv("mm_abi", "opt-shared-linux-x86_64")
+setenv("mm_target", "opt")
+setenv("mm_compiler", "gcc")
+setenv("mm_prefix", "/opt/myproject/gcc/opt-shared-linux-x86_64")
+setenv("mm_bldroot", "/tmp/builds/myproject/gcc")
+setenv("mm_targets", "opt,shared")
+setenv("mm_compilers", "gcc")
+
+prepend_path("PATH", "/opt/myproject/gcc/opt-shared-linux-x86_64/bin")
+prepend_path("PYTHONPATH", "/opt/myproject/gcc/opt-shared-linux-x86_64/packages")
+prepend_path("LD_LIBRARY_PATH", "/opt/myproject/gcc/opt-shared-linux-x86_64/lib")
+
+whatis("myproject built with gcc, optimized")
+```
+
+### Injecting Build Environment
+
+mm can generate shell commands to set up the build environment:
+
+```bash
+# For bash/sh
+eval $(mm --paths=sh)
+
+# For csh/tcsh
+eval `mm --paths=csh`
+
+# For fish
+eval (mm --paths=fish)
+
+# This sets: PATH, PYTHONPATH, MM_INCLUDES, MM_LIBPATH
+```
+
+This is useful for:
+- Running binaries built by mm
+- Using Python packages built by mm
+- Linking against libraries built by mm
+
+To remove mm paths from environment:
+
+```bash
+eval $(mm --paths=sh --clear)
+```
+
+## Project Configuration
+
+Override defaults in `.mm/myproject.mm`:
+
+```makefile
+# -*- Makefile -*-
+
+# Set project name (optional, defaults to directory name)
+project := myproject
+
+# Compiler flags for everything
+myproject.common.c++.flags := -Wall -O3 $($(compiler.c++).std.c++20)
+
+# Apply to all libraries
+${foreach lib, $(myproject.libraries), \
+    ${eval $(lib).c++.flags := $(myproject.common.c++.flags)} \
+}
+```
+
+## Next Steps
+
+- See `examples/hello/` for a comprehensive multi-language project
+- See `examples/simple/` for minimal examples
+- Read [Examples Explained](examples.md) for detailed walkthroughs
+- Read [Command-Line Reference](command-line-reference.md) for all options
+- Use `mm --help` for built-in help
+- Use `mm <project>.help` or `mm <asset>.info` for runtime target information
+
+## Summary
+
+The mm philosophy:
+1. **Declare what you're building** in `.mm/{project}.mm`
+2. **Organize code by directory structure**
+3. **Let mm discover and build everything**
+
+No makefiles. No CMakeLists. Just code and a simple declaration file.


### PR DESCRIPTION
## Summary

- Add comprehensive documentation for mm: quickstart guide, FAQ (30+ questions), examples walkthrough, command-line reference, and repository guidelines (AGENTS.md)
- Fix several factual errors carried over from earlier drafts

## Changes

**New files:**
- `docs/quickstart.md` — 5-minute getting started guide
- `docs/FAQ.md` — 30+ common questions with answers
- `docs/examples.md` — In-depth walkthrough of `examples/hello/`
- `docs/command-line-reference.md` — Full option reference
- `docs/DOCUMENTATION_PLAN.md` — Roadmap for remaining docs
- `AGENTS.md` — Repository guidelines for contributors/agents

**Modified:**
- `README.md` — Fix `--target=opt,static` (static is not a built-in variant)

**Deleted:**
- `docs/PHASE1_COMPLETE.md` — Contained false claims (e.g., `hello.mm` expanded to 266 lines when it is 71, `--guide` command added when it was not)

**Fixes:**
- Remove all references to phantom `--guide` flag (never implemented)
- Correct `--target=static` — not a built-in variant; no `make/targets/static.mm` exists. Omit `shared` to get static-only builds
- Fix FAQ claim "mm doesn't have a clean target" — `clean`, `tidy`, `tests.clean` all exist
- Fix `examples/prep/` description (test dependencies, not preprocessing)
- Fix environment variable case in AGENTS.md (`mm_prefix` not `MM_PREFIX`)
- Fill placeholder text in FAQ (issue tracker links)
- Remove undocumented `--palette=dark` from CLI reference
- Point help references to runtime targets (`mm <project>.help`, `mm <asset>.info`) instead of non-existent `--guide`