### PR TITLE
Added test runners as an alternative to the native mm test suites

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,147 @@
+# Testing with mm
+
+mm supports two complementary testing models. You can mix them freely across a
+project — each test suite picks the model that fits.
+
+1. **Per-file drivers** — the classic mm model: every test file is its own small
+   program. Silence is pass; the process exit code is the verdict.
+2. **Runners** — the suite delegates to a self-discovering test framework
+   (Playwright, Vitest, pytest, Catch2, GoogleTest). mm prepares the environment
+   the framework needs and invokes it once; the exit code is the verdict.
+
+A test suite is an asset type. It is declared in `.mm/<suite>` and wired into the
+project with `<project>.tests := <suite> …`. The suite's tests live under
+`tests/<stem>/`, discovered recursively.
+
+---
+
+## Per-file drivers
+
+Each file under the suite directory whose extension is a registered language
+source becomes a test driver. mm runs each one; **silence is pass, any output (or
+a non-zero exit) is a failure.**
+
+```makefile
+# .mm/timer.lib.tests
+timer.lib.tests.stem   := timer.lib
+timer.lib.tests.extern := timer.lib
+```
+
+**Interpreted drivers** launch as `<interpreter> <file>`:
+
+- `.py` — Python, via `python3`
+- `.mjs` — Node, via `node`
+
+**Compiled drivers** are compiled and linked into a binary that is then run; one
+binary per source file. C and C++ sources qualify.
+
+### Staged execution (opt-in)
+
+An ES-module (`.mjs`) driver in the source tree cannot resolve packages from a
+`node_modules` that lives elsewhere — Node walks up from the driver's own
+directory, and mm deliberately keeps `node_modules` out of the source tree (it
+lives in the web bundle's staging area). Opt in to *staged* execution and mm
+copies the driver into a staging directory under the build tree and links a
+`node_modules` in beside it before running:
+
+```makefile
+qed.ux.tests.staged        := yes
+qed.ux.tests.stage.modules := $(qed.ux.stage.modules)   # the bundle's node_modules
+```
+
+---
+
+## Runners
+
+Set `<suite>.runner` and the suite stops enumerating per-file drivers; instead mm
+runs the named framework once. The framework owns discovery, parallelism, and
+fixtures; for browser runners it also owns the servers under test.
+
+```makefile
+qed.ux.playwright.runner        := playwright
+qed.ux.playwright.stage.modules := $(qed.ux.stage.modules)
+```
+
+| Runner       | Language | Prepare    | Launch                | The suite supplies |
+|--------------|----------|------------|-----------------------|--------------------|
+| `playwright` | node     | `staged`   | `npx playwright test` | `stage.modules` |
+| `vitest`     | node     | `staged`   | `npx vitest run`      | `stage.modules` |
+| `pytest`     | python   | `plain`    | `pytest`              | an importable package |
+| `catch2`     | c++      | `compiled` | the built binary      | `extern := catch2`, C++17 |
+| `gtest`      | c++      | `compiled` | the built binary      | `extern := gtest`, C++17 |
+
+The **prepare** kind decides what mm does before launching:
+
+- `staged` — mirror the suite into a staging directory and link `stage.modules`
+  in as `node_modules`; run the launch command from there. (Playwright, Vitest.)
+- `plain` — nothing; run the launch command in the suite directory. (pytest.)
+- `compiled` — compile the suite's sources into one binary and run it; the binary
+  is the launch command. (Catch2, GoogleTest.)
+
+**Overrides.** A suite may refine the invocation:
+
+```makefile
+qed.ux.playwright.runner.launch := npx playwright test --project=readonly
+qed.ux.playwright.argv          := --reporter=line
+qed.ux.playwright.env           := CI=1
+```
+
+### Node runners (Playwright, Vitest)
+
+Both run `staged`, so they need a populated `node_modules`. Point `stage.modules`
+at the web bundle's modules — mm's webpack/vite bundles install into their staging
+area, which is exactly where the runner should resolve packages. Playwright's
+browser binaries are located by `PLAYWRIGHT_BROWSERS_PATH` (set it once, in your
+shell profile, to a shared cache). Servers under test, and serial-vs-parallel
+routing, belong in `playwright.config.ts` (`webServer`, projects,
+`test.describe.serial`), not in mm.
+
+### Python runner (pytest)
+
+pytest runs in the suite directory and discovers `test_*.py` itself, against the
+package the suite depends on (already importable in the active environment). No
+staging.
+
+### C++ runners (Catch2, GoogleTest)
+
+A `compiled` runner compiles every source in the suite into one binary that
+self-registers its test cases, then runs it. The suite names the framework as an
+external dependency and selects the language standard; the runner contributes the
+entry-point library (`Catch2Main`, `gtest_main`) so your sources need no `main`:
+
+```makefile
+qed.lib.catch2.runner   := catch2
+qed.lib.catch2.extern   := catch2
+qed.lib.catch2.c++.flags := $($(compiler.c++).std.c++17)
+```
+
+C++ externs are only available once `mm --setup` has recorded where they live.
+After installing a framework — or after mm gains support for a new one — the
+package database may be stale; regenerate it with `mm extern.db.clean` (the next
+build rebuilds it), and confirm with `mm extern.db.info`.
+
+---
+
+## Running and inspecting
+
+```
+mm <suite>            # build/prepare and run the suite
+mm <suite>.clean      # remove its build/staging artifacts
+mm <suite>.info       # show the suite's configuration
+mm tests              # run every suite in the project
+```
+
+---
+
+## Choosing a model
+
+- A handful of independent checks, no framework needed → **per-file drivers**
+  (silence is pass).
+- A node test that imports third-party packages or app modules → a **staged**
+  `.mjs` driver, or the **vitest** runner for a real framework with jsdom.
+- Browser/end-to-end against a running server → the **playwright** runner.
+- Python → **pytest**.
+- C++ with a framework → **catch2** or **gtest**.
+
+
+# end of file

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -498,6 +498,62 @@ a path relative to wherever you cloned it.
 
 ---
 
+## step09 — test runners
+
+Step01 ran each test as its own small program: one file, one binary or
+interpreter invocation, silence is pass. That model is perfect for many small,
+independent checks, but it sidesteps the test frameworks people often reach for.
+Step09 adds the other model — *runners* — and applies it twice: Catch2 for the
+C++ library and pytest for the Python package.
+
+A suite opts into a runner with one line; mm then stops enumerating per-file
+drivers and instead prepares what the framework needs and invokes it once,
+treating the exit code as the verdict. Both new suites are wired in alongside the
+step01-style ones:
+
+```makefile
+timer.tests := timer.lib.tests timer.pkg.tests timer.ext.tests \
+               timer.catch2 timer.pytest
+```
+
+### Catch2 for the library
+
+```makefile
+# .mm/timer.catch2
+timer.catch2.runner        := catch2
+timer.catch2.prerequisites := timer.lib
+timer.catch2.extern        := timer.lib pyre catch2
+timer.catch2.c++.flags     += $($(compiler.c++).std.c++17)
+```
+
+`runner := catch2` makes mm compile *every* `.cc` under `tests/timer.catch2/`
+into a single binary that self-registers its `TEST_CASE`s, then run it once.
+Contrast that with step01, where each `.cc` is a standalone program with its own
+`main`: here the sources carry only `TEST_CASE`s, and the runner links the
+`Catch2Main` entry point for you. Catch2 must be installed and recorded in the
+package database (`mm --setup`); the `extern := … catch2` line puts its headers
+and library on the command lines.
+
+### pytest for the package
+
+```makefile
+# .mm/timer.pytest
+timer.pytest.runner        := pytest
+timer.pytest.prerequisites := timer.pkg
+```
+
+pytest runs in place, discovers `test_*.py` under `tests/timer.pytest/`, and runs
+them against the built package — no per-file wiring, no staging. The test files
+use plain `assert`s and `test_*` functions instead of the step01 convention of a
+`test()` returning a status code.
+
+Per-file drivers and runners coexist in the same project; pick whichever fits a
+given suite. For the full set of strategies — including `.mjs`/node drivers,
+staged execution, and the Playwright, Vitest, and GoogleTest runners — see
+[`testing.md`](testing.md).
+
+---
+
 ## What the steps demonstrate together
 
 | Step | New concept |
@@ -511,10 +567,12 @@ a path relative to wherever you cloned it.
 | 06 | `pyre.application`; traits; `self.argv`; built-in channels |
 | 07 | Protocols and components; `pyre_default`; runtime implementation selection |
 | 08 | `mm --activate`; `mm --branch`; branch-scoped build isolation |
+| 09 | Test runners; Catch2 for the library, pytest for the package |
 
 The progression is deliberate. Steps 00–04 build a working tool with no
 external dependencies beyond pybind11. Steps 05–07 add pyre incrementally,
 each step showing one layer of the framework. Step08 closes the loop by showing
-how the build system integrates with the development workflow.
+how the build system integrates with the development workflow, and step09 adds
+test frameworks alongside the per-file tests from step01.
 
 # end of file

--- a/examples/step09/.clang-format
+++ b/examples/step09/.clang-format
@@ -1,0 +1,123 @@
+# -*- yaml -*-
+
+---
+Language:        Cpp
+AccessModifierOffset: -4
+AlignAfterOpenBracket: AlwaysBreak
+AlignConsecutiveAssignments:
+  Enabled:         false
+AlignConsecutiveBitFields:
+  Enabled:         false
+AlignConsecutiveDeclarations:
+  Enabled:         false
+AlignConsecutiveMacros:
+  Enabled:         false
+AlignEscapedNewlines: Left
+AlignOperands:   AlignAfterOperator
+AlignTrailingComments:
+  Kind:            Always
+  OverEmptyLines:  0
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: Inline
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: TopLevel
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: BinPack
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterExternBlock: false
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Custom
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializers: AfterColon
+BreakInheritanceList: AfterColon
+BreakStringLiterals: true
+ColumnLimit:     100
+CommentPragmas:  ''
+CompactNamespaces: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DisableFormat:   false
+FixNamespaceComments: true
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeBlocks:   Preserve
+IndentCaseBlocks: false
+IndentCaseLabels: true
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+KeepEmptyLines:
+  AtEndOfFile:     false
+  AtStartOfBlock:  false
+  AtStartOfFile:   false
+LambdaBodyIndentation: Signature
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: All
+PackConstructorInitializers: Never
+PenaltyBreakAssignment: 1
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 1
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 1
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Middle
+QualifierAlignment: Left
+ReflowComments:  true
+SortIncludes:
+  Enabled:         false
+SortUsingDeclarations: Never
+SpaceAfterCStyleCast: true
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInContainerLiterals: true
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParens:  Never
+SpacesInSquareBrackets: false
+Standard:        c++20
+TabWidth:        4
+LineEnding:      LF
+UseTab:          Never
+...

--- a/examples/step09/.mm/timer.catch2
+++ b/examples/step09/.mm/timer.catch2
@@ -1,0 +1,19 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# the Catch2 runner suite for the timer library
+timer.catch2.stem := timer.catch2
+# delegate to the catch2 runner: compile every source into one self-registering binary and run it
+timer.catch2.runner := catch2
+# the library must be built before its tests can be compiled
+timer.catch2.prerequisites := timer.lib
+# headers and libraries: the library under test, its pyre dependency, and the Catch2 framework
+timer.catch2.extern := timer.lib pyre catch2
+# the language standard the library uses
+timer.catch2.c++.flags += $($(compiler.c++).std.c++17)
+
+
+# end of file

--- a/examples/step09/.mm/timer.ext
+++ b/examples/step09/.mm/timer.ext
@@ -1,0 +1,23 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# the timer pybind11 extension
+timer.ext.stem := timer
+
+# these are bindings for
+timer.ext.wraps := timer.lib
+
+# no capsule sharing with other extensions
+timer.ext.capsule :=
+
+# external dependencies
+timer.ext.extern := timer.lib pyre pybind11 python
+
+# match the language standard used by the library
+timer.ext.lib.c++.flags += $($(compiler.c++).std.c++17)
+
+
+# end of file

--- a/examples/step09/.mm/timer.ext.tests
+++ b/examples/step09/.mm/timer.ext.tests
@@ -1,0 +1,13 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# the test suite for the timer extension
+timer.ext.tests.stem := timer.ext
+# both the package (for __init__.py files) and the extension .so must exist before tests run
+timer.ext.tests.prerequisites := timer.pkg timer.ext
+
+
+# end of file

--- a/examples/step09/.mm/timer.lib
+++ b/examples/step09/.mm/timer.lib
@@ -1,0 +1,29 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# the timer library
+timer.lib.stem := timer
+timer.lib.root := lib/timer/
+
+# external dependencies
+timer.lib.extern := pyre
+
+# enable the journal debug channels
+timer.lib.c++.defines += JOURNAL_DEBUG
+# c++17 for std::chrono::steady_clock and friends
+timer.lib.c++.flags += $($(compiler.c++).std.c++17)
+
+# version header is generated from a template at build time
+timer.lib.headers.autogen := version.h.in
+# the substitution table: token|value pairs, one per line
+timer.lib.autogen = \
+    @MAJOR@|$(timer.major) \
+    @MINOR@|$(timer.minor) \
+    @MICRO@|$(timer.micro) \
+    @REVISION@|$(timer.revision) \
+
+
+# end of file

--- a/examples/step09/.mm/timer.lib.tests
+++ b/examples/step09/.mm/timer.lib.tests
@@ -1,0 +1,17 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# the test suite for the timer library
+timer.lib.tests.stem := timer.lib
+# the library must be built before the tests can be compiled or run
+timer.lib.tests.prerequisites := timer.lib
+# inherit the library's include and link paths
+timer.lib.tests.extern := timer.lib pyre
+# same language standard as the library under test
+timer.lib.tests.c++.flags += $($(compiler.c++).std.c++17)
+
+
+# end of file

--- a/examples/step09/.mm/timer.mm
+++ b/examples/step09/.mm/timer.mm
@@ -1,0 +1,20 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# the project assets
+timer.packages := timer.pkg
+timer.libraries := timer.lib
+timer.extensions := timer.ext
+timer.tests := timer.lib.tests timer.pkg.tests timer.ext.tests timer.catch2 timer.pytest
+
+# load configurations
+include $(timer.packages)
+include $(timer.libraries)
+include $(timer.extensions)
+include $(timer.tests)
+
+
+# end of file

--- a/examples/step09/.mm/timer.pkg
+++ b/examples/step09/.mm/timer.pkg
@@ -1,0 +1,13 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# the timer python package
+timer.pkg.stem := timer
+# the command-line driver installed into {prefix}/bin/
+timer.pkg.drivers := timer
+
+
+# end of file

--- a/examples/step09/.mm/timer.pkg.tests
+++ b/examples/step09/.mm/timer.pkg.tests
@@ -1,0 +1,13 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# the test suite for the timer python package
+timer.pkg.tests.stem := timer.pkg
+# the package must be built and on PYTHONPATH before the tests can run
+timer.pkg.tests.prerequisites := timer.pkg
+
+
+# end of file

--- a/examples/step09/.mm/timer.pytest
+++ b/examples/step09/.mm/timer.pytest
@@ -1,0 +1,15 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# the pytest runner suite for the timer python package
+timer.pytest.stem := timer.pytest
+# delegate to the pytest runner: discover test_*.py in place and run them
+timer.pytest.runner := pytest
+# the package must be built and importable before the tests run
+timer.pytest.prerequisites := timer.pkg
+
+
+# end of file

--- a/examples/step09/bin/timer
+++ b/examples/step09/bin/timer
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+# support
+import subprocess
+
+# pyre
+import pyre
+
+# the timer package
+import timer
+
+
+class App(pyre.application, family="timer.app"):
+    """
+    Time the execution of an arbitrary shell command.
+    """
+
+    # user configurable state
+    count = pyre.properties.int(default=1)
+    count.doc = "number of times to run the command"
+
+    clock = timer.protocols.timer()
+    clock.doc = "the timer implementation to use"
+
+    # the main entry point
+    @pyre.export
+    def main(self, *args, **kwds):
+        """
+        Run the command {count} times and report wall-clock timing.
+        """
+        # collect the command to time from the remaining arguments
+        command = list(self.argv)
+        # a command is required
+        if not command:
+            self.error.log("no command specified")
+            return 1
+
+        # use the configured timer; reset it between runs
+        clock = self.clock
+        samples = []
+        result = None
+        for _ in range(self.count):
+            clock.reset()
+            clock.start()
+            result = subprocess.run(command)
+            clock.stop()
+            samples.append(clock.elapsed)
+
+        # single run: one number
+        if self.count == 1:
+            self.info.log(f"{samples[0]:.6f} s")
+            return result.returncode
+
+        # multiple runs: min / avg / max
+        self.info.line(f"min: {min(samples):.6f} s")
+        self.info.line(f"avg: {sum(samples) / len(samples):.6f} s")
+        self.info.log(f"max: {max(samples):.6f} s")
+        return result.returncode
+
+
+# main
+if __name__ == "__main__":
+    app = App(name="timer")
+    status = app.run()
+    raise SystemExit(status)

--- a/examples/step09/etc/bash/activate.bash
+++ b/examples/step09/etc/bash/activate.bash
@@ -1,0 +1,32 @@
+# -*- shell-script -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+#
+# mm session management functions
+# source this file from ~/.bashrc or ~/.bash_profile
+
+
+mm.activate() {
+    # wire the current mm installation into the shell session:
+    # prepends {prefix}/bin to PATH and the Python package directory to PYTHONPATH;
+    # undoes the previous activation first so re-invoking is always safe
+    eval "$(mm --quiet --activate)"
+}
+
+mm.branch() {
+    # tag the build context with the current git branch ({project}/{branch}),
+    # then activate the corresponding installation tree;
+    # subsequent mm invocations build into and install to a branch-scoped prefix,
+    # leaving all other branch builds untouched
+    eval "$(mm --quiet --branch=on)"
+}
+
+mm.clear() {
+    # remove the branch tag and activate the unscoped installation tree;
+    # undoes the effect of mm.branch and returns to the mainline build
+    eval "$(mm --quiet --branch=off)"
+}
+
+
+# end of file

--- a/examples/step09/ext/timer/Timer.cc
+++ b/examples/step09/ext/timer/Timer.cc
@@ -1,0 +1,63 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+// portability
+#include <portinfo>
+// external
+#include "external.h"
+// namespace setup
+#include "forward.h"
+
+
+// bind the {Timer} class
+void
+timer::py::Timer(py::module & m)
+{
+    // type alias
+    using timer_t = timer::Timer;
+
+    // create the class
+    auto cls = py::class_<timer_t>(m, "Timer");
+
+    // constructors
+    cls.def(
+        // the default constructor
+        py::init<>());
+
+    // interface
+    cls.def(
+        // the name
+        "start",
+        // the implementation; discard the C++ reference return so Python gets None
+        [](timer_t & t) { t.start(); },
+        // the docstring
+        "start the timer; no-op if already running");
+
+    cls.def(
+        "stop", [](timer_t & t) { t.stop(); },
+        "stop the timer and accumulate elapsed time; no-op if not running");
+
+    cls.def(
+        "reset", [](timer_t & t) { t.reset(); }, "clear the accumulated time and stop the timer");
+
+    // read-only properties
+    cls.def_property_readonly(
+        // the name
+        "elapsed",
+        // the getter
+        &timer_t::elapsed,
+        // the docstring
+        "accumulated time in seconds, including any open interval");
+
+    cls.def_property_readonly(
+        "running", &timer_t::running, "whether the timer is currently running");
+
+    // all done
+    return;
+}
+
+
+// end of file

--- a/examples/step09/ext/timer/__init__.cc
+++ b/examples/step09/ext/timer/__init__.cc
@@ -1,0 +1,30 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+// portability
+#include <portinfo>
+// external
+#include "external.h"
+// namespace setup
+#include "forward.h"
+// sub-namespace initializers
+#include "__init__.h"
+
+
+// the module entry point
+PYBIND11_MODULE(timer, m)
+{
+    // the doc string
+    m.doc() = "the timer C++ extension module";
+
+    // version info
+    timer::py::version(m);
+    // the Timer class
+    timer::py::Timer(m);
+}
+
+
+// end of file

--- a/examples/step09/ext/timer/__init__.h
+++ b/examples/step09/ext/timer/__init__.h
@@ -1,0 +1,11 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+// code guard
+#pragma once
+
+
+// end of file

--- a/examples/step09/ext/timer/external.h
+++ b/examples/step09/ext/timer/external.h
@@ -1,0 +1,28 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+// code guard
+#pragma once
+
+// pybind11 support
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+// the timer library
+#include <timer/public.h>
+
+// type aliases
+namespace timer::py {
+    // pull in pybind11
+    namespace py = pybind11;
+    // get the special {pybind11} literals
+    using namespace py::literals;
+    // strings
+    using string_t = std::string;
+} // namespace timer::py
+
+
+// end of file

--- a/examples/step09/ext/timer/forward.h
+++ b/examples/step09/ext/timer/forward.h
@@ -1,0 +1,22 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+// code guard
+#pragma once
+
+// get the external declarations
+#include "external.h"
+
+// the {timer::py} namespace
+namespace timer::py {
+    // the version submodule
+    void version(py::module &);
+    // the Timer class
+    void Timer(py::module &);
+} // namespace timer::py
+
+
+// end of file

--- a/examples/step09/ext/timer/version.cc
+++ b/examples/step09/ext/timer/version.cc
@@ -1,0 +1,58 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+// portability
+#include <portinfo>
+// external
+#include "external.h"
+// namespace setup
+#include "forward.h"
+
+
+// add a {version} submodule that exposes both compile-time and run-time version info
+void
+timer::py::version(py::module & m)
+{
+    // make the submodule
+    auto version = m.def_submodule(
+        // its name
+        "version",
+        // its docstring
+        "the static and dynamic version of the extension");
+
+    // static version: values baked in from the headers at compile time
+    version.def(
+        // the name
+        "static",
+        // the implementation
+        []() {
+            return std::make_tuple(
+                timer::version::major, timer::version::minor, timer::version::micro,
+                timer::version::revision);
+        },
+        // the docstring
+        "the timer version visible at compile time");
+
+    // dynamic version: values provided by the shared library at run time
+    version.def(
+        // the name
+        "dynamic",
+        // the implementation
+        []() {
+            // ask the shared library
+            const auto v = timer::version::version();
+            // pack into a tuple
+            return std::make_tuple(v.major, v.minor, v.micro, v.revision);
+        },
+        // the docstring
+        "the timer version visible through the shared library");
+
+    // all done
+    return;
+}
+
+
+// end of file

--- a/examples/step09/lib/timer/Timer.cc
+++ b/examples/step09/lib/timer/Timer.cc
@@ -1,0 +1,66 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// portability
+#include <portinfo>
+// my declarations
+#include "Timer.h"
+// support
+#include <pyre/journal.h>
+
+
+// interface
+auto
+timer::Timer::start() -> Timer &
+{
+    // only act if the timer is not already running
+    if (!_running) {
+        // record the start time
+        _start = clock_type::now();
+        // mark as running
+        _running = true;
+        // leave a note
+        auto channel = pyre::journal::debug_t("timer.Timer");
+        channel << "start" << pyre::journal::endl;
+    }
+    // all done
+    return *this;
+}
+
+auto
+timer::Timer::stop() -> Timer &
+{
+    // only act if the timer is actually running
+    if (_running) {
+        // accumulate the elapsed time for this interval
+        _elapsed += clock_type::now() - _start;
+        // mark as stopped
+        _running = false;
+        // leave a note
+        auto channel = pyre::journal::debug_t("timer.Timer");
+        channel << "stop" << pyre::journal::endl;
+    }
+    // all done
+    return *this;
+}
+
+auto
+timer::Timer::reset() -> Timer &
+{
+    // stop the timer
+    _running = false;
+    // clear accumulated time
+    _elapsed = duration_type { 0 };
+    // leave a note
+    auto channel = pyre::journal::debug_t("timer.Timer");
+    channel << "reset" << pyre::journal::endl;
+    // all done
+    return *this;
+}
+
+
+// end of file

--- a/examples/step09/lib/timer/Timer.h
+++ b/examples/step09/lib/timer/Timer.h
@@ -1,0 +1,60 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+// code guard
+#pragma once
+
+
+// support
+#include <chrono>
+// declarations
+#include "forward.h"
+
+
+// a wall-clock timer with accumulation across multiple start/stop cycles
+class timer::Timer {
+    // types
+public:
+    using clock_type = std::chrono::steady_clock;
+    using time_point_type = clock_type::time_point;
+    using duration_type = std::chrono::duration<double>; // in seconds
+
+    // interface
+public:
+    // start the timer; no-op if already running
+    auto start() -> Timer &;
+    // stop the timer and accumulate elapsed time; no-op if not running
+    auto stop() -> Timer &;
+    // reset the accumulated time and stop the timer
+    auto reset() -> Timer &;
+
+    // read the accumulated time in seconds, including any currently running interval
+    auto elapsed() const -> double;
+    // check whether the timer is currently running
+    auto running() const -> bool;
+
+    // special members
+public:
+    Timer() = default;
+    Timer(const Timer &) = default;
+    Timer(Timer &&) = default;
+    Timer & operator=(const Timer &) = default;
+    Timer & operator=(Timer &&) = default;
+    ~Timer() = default;
+
+    // data
+private:
+    bool _running { false };
+    time_point_type _start {};
+    duration_type _elapsed { 0 };
+};
+
+
+// inline definitions
+#include "Timer.icc"
+
+
+// end of file

--- a/examples/step09/lib/timer/Timer.icc
+++ b/examples/step09/lib/timer/Timer.icc
@@ -1,0 +1,36 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// code guard
+#pragma once
+
+// declarations
+#include "Timer.h"
+
+
+inline auto
+timer::Timer::running() const -> bool
+{
+    return _running;
+}
+
+
+inline auto
+timer::Timer::elapsed() const -> double
+{
+    // start with whatever has been accumulated from previous start/stop cycles
+    auto total = _elapsed;
+    // if the timer is still running, fold in the current open interval
+    if (_running) {
+        total += clock_type::now() - _start;
+    }
+    // convert to seconds and return
+    return total.count();
+}
+
+
+// end of file

--- a/examples/step09/lib/timer/forward.h
+++ b/examples/step09/lib/timer/forward.h
@@ -1,0 +1,18 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+// code guard
+#pragma once
+
+
+// establish the namespace and forward-declare all public classes
+namespace timer {
+    // the wall-clock timer
+    class Timer;
+} // namespace timer
+
+
+// end of file

--- a/examples/step09/lib/timer/public.h
+++ b/examples/step09/lib/timer/public.h
@@ -1,0 +1,16 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+// code guard
+#pragma once
+
+
+// the full public API; clients include this header to get everything
+#include "version.h"
+#include "Timer.h"
+
+
+// end of file

--- a/examples/step09/lib/timer/version.cc
+++ b/examples/step09/lib/timer/version.cc
@@ -1,0 +1,22 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+
+// portability
+#include <portinfo>
+// my declarations
+#include "version.h"
+
+
+// build and return the version struct
+auto
+timer::version::version() -> version_t
+{
+    return { major, minor, micro, revision };
+}
+
+
+// end of file

--- a/examples/step09/lib/timer/version.h.in
+++ b/examples/step09/lib/timer/version.h.in
@@ -1,0 +1,45 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+// code guard
+#pragma once
+
+// support
+#include <string>
+
+// N.B.:
+//  - version symbols live in their own namespace so the short names don't pollute {timer::}
+//  - {version.h} is generated from {version.h.in} at build time by substituting the
+//    @TOKEN@ placeholders with version numbers extracted from the most recent git tag;
+//    edit {version.h.in}, not {version.h}
+//  - version information is available at compile time (constants in this header) and at
+//    run time ({timer::version::version()}); comparing the two lets the application detect
+//    whether the headers it was compiled against match the shared library it linked with
+namespace timer::version {
+    // type aliases
+    using string_t = std::string;
+
+    // the version as a struct with named fields
+    struct version_t {
+        int major;
+        int minor;
+        int micro;
+        string_t revision;
+    };
+
+    // run-time query
+    auto version() -> version_t;
+
+    // compile-time constants
+    // clang-format off
+    const int major = @MAJOR@;
+    const int minor = @MINOR@;
+    const int micro = @MICRO@;
+    const string_t revision = "@REVISION@";
+    // clang-format on
+} // namespace timer::version
+
+// end of file

--- a/examples/step09/pkg/timer/Timer.py
+++ b/examples/step09/pkg/timer/Timer.py
@@ -1,0 +1,79 @@
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# support
+import time
+import timer
+
+
+# declaration
+class Timer(
+    timer.component, family="timer.timers.python", implements=timer.protocols.timer
+):
+    """
+    A wall-clock timer backed by time.perf_counter.
+    """
+
+    # obligations
+    @timer.export
+    def start(self) -> "Timer":
+        """
+        Start the timer; no-op if already running.
+        """
+        if not self._running:
+            self._start = time.perf_counter()
+            self._running = True
+        return self
+
+    @timer.export
+    def stop(self) -> "Timer":
+        """
+        Stop the timer and accumulate elapsed time; no-op if not running.
+        """
+        if self._running:
+            self._elapsed += time.perf_counter() - self._start
+            self._running = False
+        return self
+
+    @timer.export
+    def reset(self) -> "Timer":
+        """
+        Clear the accumulated time and stop the timer.
+        """
+        self._running = False
+        self._elapsed = 0.0
+        return self
+
+    # read-only interface
+    @property
+    def elapsed(self) -> float:
+        """
+        The accumulated time in seconds, including any currently open interval.
+        """
+        total = self._elapsed
+        if self._running:
+            total += time.perf_counter() - self._start
+        return total
+
+    @property
+    def running(self) -> bool:
+        """
+        Whether the timer is currently running.
+        """
+        return self._running
+
+    # metamethods
+    def __init__(self, **kwds):
+        # chain
+        super().__init__(**kwds)
+        # state
+        self._running: bool = False
+        self._start: float = 0.0
+        self._elapsed: float = 0.0
+
+
+# end of file

--- a/examples/step09/pkg/timer/__init__.py
+++ b/examples/step09/pkg/timer/__init__.py
@@ -1,0 +1,30 @@
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# publish pyre symbols so client code uses {timer.protocol}, {timer.component}, etc.
+from pyre import (
+    protocol,
+    component,
+    provides,
+    export,
+    properties,
+    application,
+    executive,
+)
+
+# register with the framework so pyre can find our config files and share directory
+package = executive.registerPackage(name="timer", file=__file__)
+home, prefix, defaults = package.layout()
+
+# publish the local modules
+from . import meta
+from . import protocols
+
+# the timer implementations
+from .Timer import Timer
+
+# end of file

--- a/examples/step09/pkg/timer/ext/CPP.py
+++ b/examples/step09/pkg/timer/ext/CPP.py
@@ -1,0 +1,68 @@
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# support
+import timer
+
+
+# declaration
+class CPP(timer.component, family="timer.timers.cpp", implements=timer.protocols.timer):
+    """
+    A wall-clock timer backed by the C++ extension.
+    """
+
+    # obligations
+    @timer.export
+    def start(self) -> "CPP":
+        """
+        Start the timer; no-op if already running.
+        """
+        self._impl.start()
+        return self
+
+    @timer.export
+    def stop(self) -> "CPP":
+        """
+        Stop the timer and accumulate elapsed time; no-op if not running.
+        """
+        self._impl.stop()
+        return self
+
+    @timer.export
+    def reset(self) -> "CPP":
+        """
+        Clear the accumulated time and stop the timer.
+        """
+        self._impl.reset()
+        return self
+
+    # read-only interface
+    @property
+    def elapsed(self) -> float:
+        """
+        The accumulated time in seconds, including any currently open interval.
+        """
+        return self._impl.elapsed
+
+    @property
+    def running(self) -> bool:
+        """
+        Whether the timer is currently running.
+        """
+        return self._impl.running
+
+    # metamethods
+    def __init__(self, **kwds):
+        # chain
+        super().__init__(**kwds)
+        # build the C++ implementation
+        from timer.ext import Timer as CppTimer
+
+        self._impl = CppTimer()
+
+
+# end of file

--- a/examples/step09/pkg/timer/ext/__init__.py
+++ b/examples/step09/pkg/timer/ext/__init__.py
@@ -1,0 +1,14 @@
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# the raw C++ backed timer
+from .timer import Timer
+
+# and its pyre component wrapper
+from .CPP import CPP
+
+# end of file

--- a/examples/step09/pkg/timer/meta.py.in
+++ b/examples/step09/pkg/timer/meta.py.in
@@ -1,0 +1,26 @@
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+# version placeholders; replaced at build time by mm
+date = "@TODAY@"
+major = @MAJOR@
+minor = @MINOR@
+micro = @MICRO@
+revision = "@REVISION@"
+
+# the version as a tuple
+version = (major, minor, micro, revision)
+
+# decorations
+copyright = "copyright (c) 1998-2026 all rights reserved"
+
+banner = f"""
+    timer {major}.{minor}.{micro} revision {revision}
+    {copyright}
+"""
+
+
+# end of file

--- a/examples/step09/pkg/timer/protocols/Timer.py
+++ b/examples/step09/pkg/timer/protocols/Timer.py
@@ -1,0 +1,58 @@
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# support
+import timer
+
+
+# declaration
+class Timer(timer.protocol, family="timer.protocols.timer"):
+    """
+    The requirements for a wall-clock timer.
+    """
+
+    # obligations
+    @timer.provides
+    def start(self):
+        """
+        Start the timer; no-op if already running.
+        """
+
+    @timer.provides
+    def stop(self):
+        """
+        Stop the timer and accumulate elapsed time; no-op if not running.
+        """
+
+    @timer.provides
+    def reset(self):
+        """
+        Clear the accumulated time and stop the timer.
+        """
+
+    # the default implementation: C++ backed if available, pure Python otherwise
+    @classmethod
+    def pyre_default(cls, **kwds):
+        """
+        Return the best available timer implementation.
+        """
+        # attempt to
+        try:
+            # get the C++ backed component
+            from timer.ext import CPP
+
+            # and return it as the default
+            return CPP
+        # if the extension is not available
+        except ImportError:
+            # fall back to the pure Python implementation
+            from timer import Timer
+
+            return Timer
+
+
+# end of file

--- a/examples/step09/pkg/timer/protocols/__init__.py
+++ b/examples/step09/pkg/timer/protocols/__init__.py
@@ -1,0 +1,11 @@
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# publish
+from .Timer import Timer as timer
+
+# end of file

--- a/examples/step09/tests/timer.catch2/elapsed.cc
+++ b/examples/step09/tests/timer.catch2/elapsed.cc
@@ -1,0 +1,28 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+// the framework
+#include <catch2/catch_test_macros.hpp>
+// the library under test
+#include <timer/Timer.h>
+
+
+TEST_CASE("elapsed is positive across an interval", "[elapsed]")
+{
+    timer::Timer t;
+    t.start();
+    // burn enough cycles that steady_clock records non-zero elapsed time
+    volatile int dummy = 0;
+    for (int i = 0; i < 1'000'000; ++i) {
+        dummy += i;
+    }
+    t.stop();
+    // the accumulated time must be strictly positive
+    REQUIRE(t.elapsed() > 0.0);
+}
+
+
+// end of file

--- a/examples/step09/tests/timer.catch2/running.cc
+++ b/examples/step09/tests/timer.catch2/running.cc
@@ -1,0 +1,27 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+// the framework
+#include <catch2/catch_test_macros.hpp>
+// the library under test
+#include <timer/Timer.h>
+
+
+TEST_CASE("running tracks start and stop", "[running]")
+{
+    timer::Timer t;
+    // a freshly constructed timer is not running
+    REQUIRE_FALSE(t.running());
+    // it is running after start()
+    t.start();
+    REQUIRE(t.running());
+    // and not running again after stop()
+    t.stop();
+    REQUIRE_FALSE(t.running());
+}
+
+
+// end of file

--- a/examples/step09/tests/timer.ext/elapsed.py
+++ b/examples/step09/tests/timer.ext/elapsed.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+# support
+import sys
+import time
+
+# the extension
+from timer.ext import timer as ext
+
+
+def test() -> int:
+    """
+    Verify that elapsed time is positive after a start/stop cycle.
+    """
+    t = ext.Timer()
+    t.start()
+    time.sleep(0.01)
+    t.stop()
+    # the elapsed time must be strictly positive
+    if t.elapsed <= 0.0:
+        print(
+            "FAILED: elapsed time should be positive after start()/stop()",
+            file=sys.stderr,
+        )
+        return 1
+    # all done
+    return 0
+
+
+# main
+if __name__ == "__main__":
+    status = test()
+    raise SystemExit(status)
+
+
+# end of file

--- a/examples/step09/tests/timer.ext/reset.py
+++ b/examples/step09/tests/timer.ext/reset.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+# support
+import sys
+import time
+
+# the extension
+from timer.ext import timer as ext
+
+
+def test() -> int:
+    """
+    Verify that reset() clears elapsed time and stops the timer.
+    """
+    t = ext.Timer()
+    t.start()
+    time.sleep(0.01)
+    t.stop()
+    # reset clears both the accumulated time and the running flag
+    t.reset()
+    if t.running:
+        print("FAILED: timer should not be running after reset()", file=sys.stderr)
+        return 1
+    if t.elapsed != 0.0:
+        print("FAILED: elapsed time should be zero after reset()", file=sys.stderr)
+        return 1
+    # all done
+    return 0
+
+
+# main
+if __name__ == "__main__":
+    status = test()
+    raise SystemExit(status)
+
+
+# end of file

--- a/examples/step09/tests/timer.ext/running.py
+++ b/examples/step09/tests/timer.ext/running.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+# support
+import sys
+
+# the extension
+from timer.ext import timer as ext
+
+
+def test() -> int:
+    """
+    Verify that running transitions correctly across start() and stop().
+    """
+    t = ext.Timer()
+    # a freshly constructed timer is not running
+    if t.running:
+        print("FAILED: timer should not be running after construction", file=sys.stderr)
+        return 1
+    # it is running after start()
+    t.start()
+    if not t.running:
+        print("FAILED: timer should be running after start()", file=sys.stderr)
+        return 1
+    # and not running again after stop()
+    t.stop()
+    if t.running:
+        print("FAILED: timer should not be running after stop()", file=sys.stderr)
+        return 1
+    # all done
+    return 0
+
+
+# main
+if __name__ == "__main__":
+    status = test()
+    raise SystemExit(status)
+
+
+# end of file

--- a/examples/step09/tests/timer.ext/sanity.py
+++ b/examples/step09/tests/timer.ext/sanity.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Sanity check: verify the timer extension is importable and its public API is present.
+"""
+
+
+def test() -> int:
+    """
+    Import the extension and spot-check the expected names.
+    """
+    # import the extension module
+    from timer.ext import timer as ext
+
+    # verify the public API is reachable
+    _ = ext.Timer
+    _ = ext.version
+    # all done
+    return 0
+
+
+# main
+if __name__ == "__main__":
+    status = test()
+    raise SystemExit(status)
+
+
+# end of file

--- a/examples/step09/tests/timer.ext/version.py
+++ b/examples/step09/tests/timer.ext/version.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify the static and dynamic versions are consistent and print both.
+"""
+
+# support
+import sys
+
+# the extension
+from timer.ext import timer as ext
+
+
+def test() -> int:
+    """
+    Compare the compile-time and run-time version tuples.
+    """
+    # query both
+    static = ext.version.static()
+    dynamic = ext.version.dynamic()
+    # show me
+    print(f"static:  {static[0]}.{static[1]}.{static[2]} rev {static[3]}")
+    print(f"dynamic: {dynamic[0]}.{dynamic[1]}.{dynamic[2]} rev {dynamic[3]}")
+    # they must agree; a mismatch means the headers and shared library are out of sync
+    if static != dynamic:
+        print("FAILED: static and dynamic versions don't match", file=sys.stderr)
+        return 1
+    # all done
+    return 0
+
+
+# main
+if __name__ == "__main__":
+    status = test()
+    raise SystemExit(status)
+
+
+# end of file

--- a/examples/step09/tests/timer.lib/elapsed.cc
+++ b/examples/step09/tests/timer.lib/elapsed.cc
@@ -1,0 +1,41 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+// portability
+#include <portinfo>
+// support
+#include <pyre/journal.h>
+#include <iostream>
+// the library
+#include <timer/Timer.h>
+
+
+int
+main(int argc, char * argv[])
+{
+    // configure journal
+    pyre::journal::application("timer.tests");
+    pyre::journal::init(argc, argv);
+
+    timer::Timer t;
+    t.start();
+    // burn enough cycles that steady_clock records non-zero elapsed time
+    volatile int dummy = 0;
+    for (int i = 0; i < 1'000'000; ++i) {
+        dummy += i;
+    }
+    t.stop();
+    // the elapsed time must be strictly positive
+    if (t.elapsed() <= 0.0) {
+        std::cerr << "FAILED: elapsed time should be positive after start()/stop()" << std::endl;
+        return 1;
+    }
+    // all done
+    return 0;
+}
+
+
+// end of file

--- a/examples/step09/tests/timer.lib/reset.cc
+++ b/examples/step09/tests/timer.lib/reset.cc
@@ -1,0 +1,46 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+// portability
+#include <portinfo>
+// support
+#include <pyre/journal.h>
+#include <iostream>
+// the library
+#include <timer/Timer.h>
+
+
+int
+main(int argc, char * argv[])
+{
+    // configure journal
+    pyre::journal::application("timer.tests");
+    pyre::journal::init(argc, argv);
+
+    timer::Timer t;
+    t.start();
+    // burn some cycles so elapsed is non-zero before the reset
+    volatile int dummy = 0;
+    for (int i = 0; i < 1'000'000; ++i) {
+        dummy += i;
+    }
+    t.stop();
+    // reset clears the accumulated time and the running flag
+    t.reset();
+    if (t.running()) {
+        std::cerr << "FAILED: timer should not be running after reset()" << std::endl;
+        return 1;
+    }
+    if (t.elapsed() != 0.0) {
+        std::cerr << "FAILED: elapsed time should be zero after reset()" << std::endl;
+        return 1;
+    }
+    // all done
+    return 0;
+}
+
+
+// end of file

--- a/examples/step09/tests/timer.lib/running.cc
+++ b/examples/step09/tests/timer.lib/running.cc
@@ -1,0 +1,46 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+// portability
+#include <portinfo>
+// support
+#include <pyre/journal.h>
+#include <iostream>
+// the library
+#include <timer/Timer.h>
+
+
+int
+main(int argc, char * argv[])
+{
+    // configure journal
+    pyre::journal::application("timer.tests");
+    pyre::journal::init(argc, argv);
+
+    // a freshly constructed timer is not running
+    timer::Timer t;
+    if (t.running()) {
+        std::cerr << "FAILED: timer should not be running after construction" << std::endl;
+        return 1;
+    }
+    // it is running after start()
+    t.start();
+    if (!t.running()) {
+        std::cerr << "FAILED: timer should be running after start()" << std::endl;
+        return 1;
+    }
+    // and not running again after stop()
+    t.stop();
+    if (t.running()) {
+        std::cerr << "FAILED: timer should not be running after stop()" << std::endl;
+        return 1;
+    }
+    // all done
+    return 0;
+}
+
+
+// end of file

--- a/examples/step09/tests/timer.lib/version.cc
+++ b/examples/step09/tests/timer.lib/version.cc
@@ -1,0 +1,43 @@
+// -*- C++ -*-
+// -*- coding: utf-8 -*-
+//
+// michael a.g. aïvázis <michael.aivazis@para-sim.com>
+// (c) 1998-2026 all rights reserved
+
+// portability
+#include <portinfo>
+// support
+#include <pyre/journal.h>
+#include <iostream>
+// the library
+#include <timer/version.h>
+
+
+int
+main(int argc, char * argv[])
+{
+    // configure journal
+    pyre::journal::application("timer.tests");
+    pyre::journal::init(argc, argv);
+
+    // get the run-time version
+    const auto v = timer::version::version();
+    // show me
+    std::cout << "version: " << v.major << "." << v.minor << "." << v.micro << " rev "
+              << v.revision << std::endl;
+    // compile-time constants must match the run-time values; a mismatch means the headers
+    // used at compile time don't belong to the shared library that was linked at run time
+    if (v.major != timer::version::major || v.minor != timer::version::minor
+        || v.micro != timer::version::micro || v.revision != timer::version::revision) {
+        // report
+        std::cerr << "version mismatch: compile-time headers don't match the shared library"
+                  << std::endl;
+        // and fail
+        return 1;
+    }
+    // all done
+    return 0;
+}
+
+
+// end of file

--- a/examples/step09/tests/timer.pkg/elapsed.py
+++ b/examples/step09/tests/timer.pkg/elapsed.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+# support
+import sys
+import time
+
+# the package
+from timer import Timer
+
+
+def test() -> int:
+    """
+    Verify that elapsed time is positive after a start/stop cycle.
+    """
+    t = Timer()
+    t.start()
+    # sleep long enough that perf_counter records non-zero elapsed time
+    time.sleep(0.01)
+    t.stop()
+    # the elapsed time must be strictly positive
+    if t.elapsed <= 0.0:
+        print(
+            "FAILED: elapsed time should be positive after start()/stop()",
+            file=sys.stderr,
+        )
+        return 1
+    # all done
+    return 0
+
+
+# main
+if __name__ == "__main__":
+    status = test()
+    raise SystemExit(status)
+
+
+# end of file

--- a/examples/step09/tests/timer.pkg/reset.py
+++ b/examples/step09/tests/timer.pkg/reset.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+# support
+import sys
+import time
+
+# the package
+from timer import Timer
+
+
+def test() -> int:
+    """
+    Verify that reset() clears elapsed time and stops the timer.
+    """
+    t = Timer()
+    t.start()
+    time.sleep(0.01)
+    t.stop()
+    # reset clears both the accumulated time and the running flag
+    t.reset()
+    if t.running:
+        print("FAILED: timer should not be running after reset()", file=sys.stderr)
+        return 1
+    if t.elapsed != 0.0:
+        print("FAILED: elapsed time should be zero after reset()", file=sys.stderr)
+        return 1
+    # all done
+    return 0
+
+
+# main
+if __name__ == "__main__":
+    status = test()
+    raise SystemExit(status)
+
+
+# end of file

--- a/examples/step09/tests/timer.pkg/running.py
+++ b/examples/step09/tests/timer.pkg/running.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+# support
+import sys
+
+# the package
+from timer import Timer
+
+
+def test() -> int:
+    """
+    Verify that running transitions correctly across start() and stop().
+    """
+    t = Timer()
+    # a freshly constructed timer is not running
+    if t.running:
+        print("FAILED: timer should not be running after construction", file=sys.stderr)
+        return 1
+    # it is running after start()
+    t.start()
+    if not t.running:
+        print("FAILED: timer should be running after start()", file=sys.stderr)
+        return 1
+    # and not running again after stop()
+    t.stop()
+    if t.running:
+        print("FAILED: timer should not be running after stop()", file=sys.stderr)
+        return 1
+    # all done
+    return 0
+
+
+# main
+if __name__ == "__main__":
+    status = test()
+    raise SystemExit(status)
+
+
+# end of file

--- a/examples/step09/tests/timer.pkg/sanity.py
+++ b/examples/step09/tests/timer.pkg/sanity.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Sanity check: verify the timer package is importable and its public API is present.
+"""
+
+
+def test() -> int:
+    """
+    Import the package and spot-check the public names.
+    """
+    # import the package
+    import timer
+
+    # verify the public API is reachable; AttributeError here is a meaningful failure
+    _ = timer.Timer
+    # all done
+    return 0
+
+
+# main
+if __name__ == "__main__":
+    status = test()
+    raise SystemExit(status)
+
+
+# end of file

--- a/examples/step09/tests/timer.pkg/version.py
+++ b/examples/step09/tests/timer.pkg/version.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+"""
+Verify the package version info is present and show it.
+"""
+
+
+def test() -> int:
+    """
+    Print the version and confirm the expected fields are present.
+    """
+    # get the metadata module
+    import timer.meta as meta
+
+    # show me
+    print(f"version: {meta.major}.{meta.minor}.{meta.micro} rev {meta.revision}")
+    # all done
+    return 0
+
+
+# main
+if __name__ == "__main__":
+    status = test()
+    raise SystemExit(status)
+
+
+# end of file

--- a/examples/step09/tests/timer.pytest/test_timer.py
+++ b/examples/step09/tests/timer.pytest/test_timer.py
@@ -1,0 +1,43 @@
+# -*- Python -*-
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# the package under test
+from timer import Timer
+
+
+def test_sanity():
+    """
+    The package is importable and its public API is present.
+    """
+    import timer
+
+    assert timer.Timer is not None
+
+
+def test_running():
+    """
+    {running} tracks start() and stop().
+    """
+    t = Timer()
+    assert not t.running
+    t.start()
+    assert t.running
+    t.stop()
+    assert not t.running
+
+
+def test_elapsed():
+    """
+    {elapsed} is non-negative and advances across an interval.
+    """
+    t = Timer()
+    t.start()
+    t.stop()
+    assert t.elapsed >= 0.0
+
+
+# end of file

--- a/make/compilers/node.mm
+++ b/make/compilers/node.mm
@@ -1,0 +1,11 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# register {node} as the {mjs} interpreter; the test launcher runs {node <source>}
+compiler.mjs ?= node
+
+
+# end of file

--- a/make/extern/catch2/init.mm
+++ b/make/extern/catch2/init.mm
@@ -1,0 +1,33 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# add me to the pile
+extern += ${if ${findstring catch2,$(extern)},,catch2}
+
+# find my configuration file
+catch2.config := ${dir ${call extern.config,catch2}}
+
+# compiler flags
+catch2.flags ?=
+# enable {catch2} aware code
+catch2.defines := WITH_CATCH2
+# the canonical form of the include directory
+catch2.incpath ?= $(catch2.dir)/include
+
+# linker flags
+catch2.ldflags ?=
+# the canonical form of the lib directory
+catch2.libpath ?= $(catch2.dir)/lib
+# its rpath
+catch2.rpath = $(catch2.libpath)
+# the names of the libraries; {Catch2Main} supplies main() and depends on {Catch2}
+catch2.libraries += Catch2Main Catch2
+
+# my dependencies
+catch2.dependencies =
+
+
+# end of file

--- a/make/extern/catch2/init.mm
+++ b/make/extern/catch2/init.mm
@@ -23,8 +23,9 @@ catch2.ldflags ?=
 catch2.libpath ?= $(catch2.dir)/lib
 # its rpath
 catch2.rpath = $(catch2.libpath)
-# the names of the libraries; {Catch2Main} supplies main() and depends on {Catch2}
-catch2.libraries += Catch2Main Catch2
+# the framework library; the {Catch2Main} entry point is added by the catch2 runner, so that
+# this extern can also serve drivers that provide their own main
+catch2.libraries += Catch2
 
 # my dependencies
 catch2.dependencies =

--- a/make/extern/catch2/rules.mm
+++ b/make/extern/catch2/rules.mm
@@ -1,0 +1,24 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# display the catch2 configuration
+extern.catch2.info:
+	@${call log.sec,"catch2",}
+	@${call log.var,"version",$(catch2.version)}
+	@${call log.var,"configuration file",$(catch2.config)}
+	@${call log.var,"home",$(catch2.dir)}
+	@${call log.var,"compiler flags",$(catch2.flags)}
+	@${call log.var,"defines",$(catch2.defines)}
+	@${call log.var,"incpath",$(catch2.incpath)}
+	@${call log.var,"linker flags",$(catch2.ldflags)}
+	@${call log.var,"libpath",$(catch2.libpath)}
+	@${call log.var,"libraries",$(catch2.libraries)}
+	@${call log.var,"dependencies",$(catch2.dependencies)}
+	@${call log.var,"c++ compile line",${call extern.compile.options,c++,catch2}}
+	@${call log.var,"c++ link line",${call extern.link.options,c++,catch2}}
+
+
+# end of file

--- a/make/languages/mjs.mm
+++ b/make/languages/mjs.mm
@@ -1,0 +1,20 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# mjs: node based test drivers
+languages.mjs.sources := .mjs
+languages.mjs.headers :=
+
+# language predicates
+languages.mjs.compiled :=
+languages.mjs.interpreted := yes
+
+# flags
+languages.mjs.categories.compile :=
+languages.mjs.categories.link :=
+
+
+# end of file

--- a/make/languages/model.mm
+++ b/make/languages/model.mm
@@ -5,7 +5,7 @@
 
 
 # initialize the list of known languages
-languages := c c++ fortran python cython cuda javascript graphql
+languages := c c++ fortran python cython cuda javascript graphql mjs
 
 # load the known languages
 include $(languages:%=make/languages/%.mm)

--- a/make/merlin.mm
+++ b/make/merlin.mm
@@ -21,7 +21,7 @@ config.db += ${if $(user.environment),$(user.environment) $(user.environment)@$(
 define model :=
     log mm
     languages platforms hosts users developers
-    compilers targets builder
+    compilers targets builder runners
 	extern projects
 endef
 

--- a/make/platforms/darwin/arm64.mm
+++ b/make/platforms/darwin/arm64.mm
@@ -5,7 +5,7 @@
 
 
 # default compilers; specify as many as necessary in the form {family} or {family/language}
-platform.compilers = clang gcc/gfortran python cython
+platform.compilers = clang gcc/gfortran python cython node
 
 # clean up the debug symbols compilers leave behind
 #     platform.clean {stem}

--- a/make/platforms/darwin/x86_64.mm
+++ b/make/platforms/darwin/x86_64.mm
@@ -5,7 +5,7 @@
 
 
 # default compilers; specify as many as necessary in the form {family} or {family/language}
-platform.compilers = gcc python cython
+platform.compilers = gcc python cython node
 
 # clean up the debug symbols compilers leave behind
 #     platform.clean {stem}

--- a/make/platforms/linux/aarch64.mm
+++ b/make/platforms/linux/aarch64.mm
@@ -5,7 +5,7 @@
 
 
 # default compilers; specify as many as necessary in the form {family} or {family/language}
-platform.compilers = gcc nvcc python cython
+platform.compilers = gcc nvcc python cython node
 
 # clean up the debug symbols compilers leave behind
 #     platform.clean {stem}

--- a/make/platforms/linux/ppc64le.mm
+++ b/make/platforms/linux/ppc64le.mm
@@ -5,7 +5,7 @@
 
 
 # default compilers; specify as many as necessary in the form {family} or {family/language}
-platform.compilers = gcc nvcc python cython
+platform.compilers = gcc nvcc python cython node
 
 # clean up the debug symbols compilers leave behind
 #     platform.clean {stem}

--- a/make/platforms/linux/x86_64.mm
+++ b/make/platforms/linux/x86_64.mm
@@ -5,7 +5,7 @@
 
 
 # default compilers; specify as many as necessary in the form {family} or {family/language}
-platform.compilers = gcc nvcc python cython
+platform.compilers = gcc nvcc python cython node
 
 # clean up the debug symbols compilers leave behind
 #     platform.clean {stem}

--- a/make/runners/catch2.mm
+++ b/make/runners/catch2.mm
@@ -1,0 +1,14 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# catch2: a compiled C++ runner; mm compiles all of the suite's sources into a single binary that
+# self-registers its TEST_CASEs, then runs it once; the suite supplies {extern := catch2} so the
+# Catch2 headers and libraries land on the compile and link command lines
+runner.catch2.prepare := compiled
+runner.catch2.language := c++
+
+
+# end of file

--- a/make/runners/catch2.mm
+++ b/make/runners/catch2.mm
@@ -6,9 +6,11 @@
 
 # catch2: a compiled C++ runner; mm compiles all of the suite's sources into a single binary that
 # self-registers its TEST_CASEs, then runs it once; the suite supplies {extern := catch2} so the
-# Catch2 headers and libraries land on the compile and link command lines
+# Catch2 headers and library land on the command lines, and the runner links {Catch2Main} to
+# provide the entry point
 runner.catch2.prepare := compiled
 runner.catch2.language := c++
+runner.catch2.libraries := Catch2Main
 
 
 # end of file

--- a/make/runners/catch2.mm
+++ b/make/runners/catch2.mm
@@ -11,6 +11,8 @@
 runner.catch2.prepare := compiled
 runner.catch2.language := c++
 runner.catch2.libraries := Catch2Main
+runner.catch2.doc := "compiled C++ runner; one binary from all sources; self-registers TEST_CASEs"
+runner.catch2.suite := "extern := catch2; c++.flags for the language standard"
 
 
 # end of file

--- a/make/runners/gtest.mm
+++ b/make/runners/gtest.mm
@@ -10,6 +10,8 @@
 runner.gtest.prepare := compiled
 runner.gtest.language := c++
 runner.gtest.libraries := gtest_main
+runner.gtest.doc := "compiled C++ runner (GoogleTest); one binary from all sources; self-registers TEST()s"
+runner.gtest.suite := "extern := gtest; c++.flags for the language standard"
 
 
 # end of file

--- a/make/runners/gtest.mm
+++ b/make/runners/gtest.mm
@@ -1,0 +1,15 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# gtest: a compiled C++ runner, like catch2; mm compiles the suite's sources into one binary
+# that self-registers its TEST()s and runs them; the suite supplies {extern := gtest}, and the
+# runner links {gtest_main} to provide the entry point that discovers and runs the cases
+runner.gtest.prepare := compiled
+runner.gtest.language := c++
+runner.gtest.libraries := gtest_main
+
+
+# end of file

--- a/make/runners/model.mm
+++ b/make/runners/model.mm
@@ -18,7 +18,12 @@ ${foreach runner,$(runners), \
     ${eval runner.$(runner).env ?=} \
     ${eval runner.$(runner).language ?=} \
     ${eval runner.$(runner).libraries ?=} \
+    ${eval runner.$(runner).doc ?=} \
+    ${eval runner.$(runner).suite ?=} \
 }
+
+# build the per-runner info recipes
+${foreach runner,$(runners),${eval ${call runner.recipes.info,$(runner)}}}
 
 
 # end of file

--- a/make/runners/model.mm
+++ b/make/runners/model.mm
@@ -5,7 +5,7 @@
 
 
 # the registry of known test runners
-runners := playwright vitest
+runners := playwright vitest pytest catch2
 
 # load each runner's description
 include $(runners:%=make/runners/%.mm)
@@ -13,8 +13,10 @@ include $(runners:%=make/runners/%.mm)
 # fill in defaults for anything a runner left unset, so the workflow can reference them safely
 ${foreach runner,$(runners), \
     ${eval runner.$(runner).prepare ?= plain} \
+    ${eval runner.$(runner).launch ?=} \
     ${eval runner.$(runner).argv ?=} \
     ${eval runner.$(runner).env ?=} \
+    ${eval runner.$(runner).language ?=} \
 }
 
 

--- a/make/runners/model.mm
+++ b/make/runners/model.mm
@@ -5,7 +5,7 @@
 
 
 # the registry of known test runners
-runners := playwright vitest pytest catch2
+runners := playwright vitest pytest catch2 gtest
 
 # load each runner's description
 include $(runners:%=make/runners/%.mm)
@@ -17,6 +17,7 @@ ${foreach runner,$(runners), \
     ${eval runner.$(runner).argv ?=} \
     ${eval runner.$(runner).env ?=} \
     ${eval runner.$(runner).language ?=} \
+    ${eval runner.$(runner).libraries ?=} \
 }
 
 

--- a/make/runners/model.mm
+++ b/make/runners/model.mm
@@ -1,0 +1,21 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# the registry of known test runners
+runners := playwright vitest
+
+# load each runner's description
+include $(runners:%=make/runners/%.mm)
+
+# fill in defaults for anything a runner left unset, so the workflow can reference them safely
+${foreach runner,$(runners), \
+    ${eval runner.$(runner).prepare ?= plain} \
+    ${eval runner.$(runner).argv ?=} \
+    ${eval runner.$(runner).env ?=} \
+}
+
+
+# end of file

--- a/make/runners/playwright.mm
+++ b/make/runners/playwright.mm
@@ -9,6 +9,8 @@
 # serial vs parallel routing and server fixtures are its concern, not ours
 runner.playwright.prepare := staged
 runner.playwright.launch := npx playwright test
+runner.playwright.doc := "node end-to-end runner; owns the browsers and the servers under test"
+runner.playwright.suite := "stage.modules: the ux bundle's node_modules"
 
 
 # end of file

--- a/make/runners/playwright.mm
+++ b/make/runners/playwright.mm
@@ -1,0 +1,14 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# playwright: a node-based end-to-end runner; it needs the client's node_modules, so it runs from
+# a staging area; it discovers its own specs and starts servers through playwright.config.ts, so
+# serial vs parallel routing and server fixtures are its concern, not ours
+runner.playwright.prepare := staged
+runner.playwright.launch := npx playwright test
+
+
+# end of file

--- a/make/runners/pytest.mm
+++ b/make/runners/pytest.mm
@@ -9,6 +9,8 @@
 # staging
 runner.pytest.prepare := plain
 runner.pytest.launch := pytest
+runner.pytest.doc := "the python test runner; discovers test_*.py and runs in place"
+runner.pytest.suite := "prerequisites: the package under test"
 
 
 # end of file

--- a/make/runners/pytest.mm
+++ b/make/runners/pytest.mm
@@ -1,0 +1,14 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# pytest: the python test runner; it runs in place and discovers test_*.py itself, against the
+# package the suite depends on (already importable in the active environment), so it needs no
+# staging
+runner.pytest.prepare := plain
+runner.pytest.launch := pytest
+
+
+# end of file

--- a/make/runners/rules.mm
+++ b/make/runners/rules.mm
@@ -1,0 +1,37 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# the runner registry summary
+runners.info: mm.banner
+	@${call log.sec,"runners","the available test runners"}
+	@$(log)
+	@${foreach runner,$(runners),${call log.var,$(runner),$(runner.$(runner).doc)};}
+	@$(log)
+	@$(log) "a test suite delegates to one with"
+	@$(log) "    <suite>.runner := ${firstword $(runners)}"
+	@$(log)
+	@$(log) "for the settings of a specific runner, use"
+	@$(log) "    mm runners.${firstword $(runners)}.info"
+	@$(log)
+
+
+# make a recipe that logs the settings of a single runner
+#  usage: runner.recipes.info {runner}
+define runner.recipes.info =
+runners.$(runner).info:
+	@${call log.sec,$(runner),$(runner.$(runner).doc)}
+	@${call log.var,prepare,$(runner.$(runner).prepare)}
+	@${call log.var,language,$(runner.$(runner).language)}
+	@${call log.var,launch,$(runner.$(runner).launch)}
+	@${call log.var,libraries,$(runner.$(runner).libraries)}
+	@${call log.var,argv,$(runner.$(runner).argv)}
+	@${call log.var,env,$(runner.$(runner).env)}
+	@${call log.var,suite,$(runner.$(runner).suite)}
+# all done
+endef
+
+
+# end of file

--- a/make/runners/vitest.mm
+++ b/make/runners/vitest.mm
@@ -1,0 +1,13 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# vitest: the vite-native unit and component runner; like playwright it needs node_modules and so
+# runs from the staging area; {run} forces a single non-watch pass so the exit code is the verdict
+runner.vitest.prepare := staged
+runner.vitest.launch := npx vitest run
+
+
+# end of file

--- a/make/runners/vitest.mm
+++ b/make/runners/vitest.mm
@@ -8,6 +8,8 @@
 # runs from the staging area; {run} forces a single non-watch pass so the exit code is the verdict
 runner.vitest.prepare := staged
 runner.vitest.launch := npx vitest run
+runner.vitest.doc := "vite-native unit and component runner; jsdom for DOM tests"
+runner.vitest.suite := "stage.modules: the ux bundle's node_modules"
 
 
 # end of file

--- a/make/tests/init.mm
+++ b/make/tests/init.mm
@@ -56,7 +56,10 @@ define tests.init =
 
     # the directory structure
     ${eval $(2).directories ?= ${call test.directories,$(2)}}
-    ${eval $(2).drivers ?= ${if $($(2).runner),,${call test.drivers,$(2)}}}
+    # a runner that self-discovers at runtime needs no source list from mm; a {compiled} runner
+    # does, since mm must compile the suite's sources into the runner binary
+    ${eval $(2).discover ?= ${if $($(2).runner),${filter compiled,$(runner.$($(2).runner).prepare)},yes}}
+    ${eval $(2).drivers ?= ${if $($(2).discover),${call test.drivers,$(2)},}}
 
     # build the language specific option database
     ${eval $(2).languages ?= ${call test.languages,$(2)}}

--- a/make/tests/init.mm
+++ b/make/tests/init.mm
@@ -63,6 +63,12 @@ define tests.init =
     ${eval $(2).rpath ?=}
     ${eval $(2).libraries ?=}
 
+    # opt-in staged execution: copy interpreted drivers into a staging area that carries a
+    # {node_modules}, so module resolution succeeds without a {node_modules} in the source tree
+    ${eval $(2).staged ?=}
+    ${eval $(2).stage.prefix ?= $($(1).tmpdir)$(2)/}
+    ${eval $(2).stage.modules ?=}
+
     # derived quantities
     ${eval $(2).staging.targets ?= ${call test.staging.targets,$(2)}}
     ${eval $(2).staging.directories ?= ${call test.staging.directories,$(2)}}
@@ -79,7 +85,7 @@ define tests.init =
     # category documentation
     $(2).meta.general := project stem name
     $(2).meta.extern := extern.requested extern.supported extern.available
-    $(2).meta.artifacts := root prefix
+    $(2).meta.artifacts := root prefix staged stage.prefix stage.modules
 
     # document each one
     # general
@@ -93,6 +99,9 @@ define tests.init =
     # artifacts
     $(2).metadoc.root := "the path to the test suite directory relative to the project directory"
     $(2).metadoc.prefix := "the absolute path to the test suite"
+    $(2).metadoc.staged := "whether interpreted drivers run from a staging area (opt-in)"
+    $(2).metadoc.stage.prefix := "the staging directory where drivers and node_modules are assembled"
+    $(2).metadoc.stage.modules := "an existing node_modules to link into the staging area"
 
 endef
 
@@ -199,6 +208,9 @@ define test.staging.target =
         ${eval $(_trgt).libpath ?= $($(1).libpath)}
         ${eval $(_trgt).rpath ?= $($(1).rpath)}
         ${eval $(_trgt).libraries ?= $($(1).libraries)}
+        ${eval $(_trgt).staged ?= $($(1).staged)}
+        ${eval $(_trgt).stage.prefix ?= $($(1).stage.prefix)}
+        ${eval $(_trgt).stage.modules ?= $($(1).stage.modules)}
         ${foreach category,$(languages.$($(_trgt).language).categories.compile), \
             ${eval $(_trgt).$($(_trgt).language).$(category) ?=} \
         }

--- a/make/tests/init.mm
+++ b/make/tests/init.mm
@@ -21,6 +21,17 @@ define tests.init =
     # the stem for generating test suite specific names
     ${eval $(2).stem ?= $($(1).stem)}
 
+    # if set, the suite delegates to a self-discovering test runner (playwright, vitest, ...)
+    # instead of mm enumerating per-file drivers
+    ${eval $(2).runner ?=}
+    # an optional override of the runner's launch command, e.g. to select a playwright project
+    ${eval $(2).runner.launch ?=}
+    # extra environment to prefix to the runner invocation
+    ${eval $(2).env ?=}
+    # suite-level startup and teardown hooks (e.g. fixtures), as make prerequisites
+    ${eval $(2).pre ?=}
+    ${eval $(2).post ?=}
+
     # the list of external dependencies as requested by the user
     ${eval $(2).extern ?=}
     # initialize the list of requested project dependencies
@@ -45,7 +56,7 @@ define tests.init =
 
     # the directory structure
     ${eval $(2).directories ?= ${call test.directories,$(2)}}
-    ${eval $(2).drivers ?= ${call test.drivers,$(2)}}
+    ${eval $(2).drivers ?= ${if $($(2).runner),,${call test.drivers,$(2)}}}
 
     # build the language specific option database
     ${eval $(2).languages ?= ${call test.languages,$(2)}}
@@ -85,7 +96,7 @@ define tests.init =
     # category documentation
     $(2).meta.general := project stem name
     $(2).meta.extern := extern.requested extern.supported extern.available
-    $(2).meta.artifacts := root prefix staged stage.prefix stage.modules
+    $(2).meta.artifacts := root prefix runner staged stage.prefix stage.modules
 
     # document each one
     # general
@@ -99,6 +110,7 @@ define tests.init =
     # artifacts
     $(2).metadoc.root := "the path to the test suite directory relative to the project directory"
     $(2).metadoc.prefix := "the absolute path to the test suite"
+    $(2).metadoc.runner := "the self-discovering test runner this suite delegates to, if any"
     $(2).metadoc.staged := "whether interpreted drivers run from a staging area (opt-in)"
     $(2).metadoc.stage.prefix := "the staging directory where drivers and node_modules are assembled"
     $(2).metadoc.stage.modules := "an existing node_modules to link into the staging area"

--- a/make/tests/rules.mm
+++ b/make/tests/rules.mm
@@ -130,6 +130,9 @@ define test.workflows.runner =
     ${if $(runner.$(_runner).prepare),,${error unknown test runner '$(_runner)' in suite '$(1)'}}
     ${eval _prepare := $(runner.$(_runner).prepare)}
     ${eval _lang := $(runner.$(_runner).language)}
+    # a compiled runner contributes its entry-point library (e.g. Catch2Main, gtest_main); fold it
+    # into the suite libraries so the link picks it up ahead of the framework library from {extern}
+    ${eval $(1).libraries += $(runner.$(_runner).libraries)}
     # the staging area (used by {staged}) and the compiled runner binary and its objects
     ${eval _stageroot := $($(1).stage.prefix)}
     ${eval _binary := $(_stageroot)$($(1).name)}

--- a/make/tests/rules.mm
+++ b/make/tests/rules.mm
@@ -87,11 +87,41 @@ ${foreach case,$($(1).staging.targets), \
 endef
 
 
+# compile one source of a {compiled} runner suite into an object under the staging root
+#   usage: test.runner.object {testsuite} {source} {language} {stageroot}
+define test.runner.object =
+    ${eval _obj := $(4)${basename ${subst $($(1).prefix),,$(2)}}$(builder.ext.obj)}
+$(_obj): $(2)
+	@${call log.action,$(3),${subst $($(1).home),,$(2)}}
+	@$(mkdirp) ${dir $(_obj)}
+	${call languages.compile,$(3),$(2),$(_obj),$(1).$(3) $(1) $($(1).extern)}
+	${call languages.makedep,$(3),$(2),$(_obj:$(builder.ext.obj)=$(builder.ext.dep)),$(1).$(3) $($(1).extern)}
+# all done
+endef
+
+
+# link the objects of a {compiled} runner suite into one self-registering test binary
+#   usage: test.runner.binary {testsuite} {language} {binary} {objects}
+define test.runner.binary =
+-include $(4:$(builder.ext.obj)=$(builder.ext.dep))
+$(3): $(4)
+	@$(mkdirp) ${dir $(3)}
+	@${call log.action,link,${subst $($(1).home),,$(3)}}
+	${call languages.link,$(2),$(4),$(3),$(1).$(2) $(1) $($(1).extern)}
+# all done
+endef
+
+
 # build targets
 # target factory for a runner suite: rather than enumerating per-file drivers, mm prepares the
-# environment a self-discovering test runner needs (playwright, vitest, pytest, ...) and invokes
-# it once, treating the process exit code as the verdict. the runner owns discovery, parallelism,
-# fixtures, and -- for browser runners -- the servers under test
+# environment a self-discovering test runner needs and invokes it once, treating the process exit
+# code as the verdict. the runner owns discovery, parallelism, fixtures, and -- for browser
+# runners -- the servers under test. the {prepare} kind decides what mm does first:
+#   staged   -- mirror the suite into a staging area and link {stage.modules} in as node_modules
+#               (playwright, vitest); run the launch command from there
+#   compiled -- compile the suite's sources into one binary and run it (catch2); the binary is
+#               the launch command
+#   plain    -- nothing; run the launch command in the suite directory (pytest)
 #   usage: test.workflows.runner {testsuite}
 define test.workflows.runner =
 
@@ -99,14 +129,24 @@ define test.workflows.runner =
     ${eval _runner := $($(1).runner)}
     ${if $(runner.$(_runner).prepare),,${error unknown test runner '$(_runner)' in suite '$(1)'}}
     ${eval _prepare := $(runner.$(_runner).prepare)}
-    # the launch command: a per-suite override wins over the runner default, then the args
-    ${eval _base := ${if $($(1).runner.launch),$($(1).runner.launch),$(runner.$(_runner).launch)}}
-    ${eval _launch := ${strip $(_base) $(runner.$(_runner).argv) $($(1).argv)}}
-    ${eval _env := ${strip $(runner.$(_runner).env) $($(1).env)}}
-    # a {staged} runner runs from the staging area that carries the node_modules; everything else
-    # runs in place, in the suite directory
+    ${eval _lang := $(runner.$(_runner).language)}
+    # the staging area (used by {staged}) and the compiled runner binary and its objects
     ${eval _stageroot := $($(1).stage.prefix)}
+    ${eval _binary := $(_stageroot)$($(1).name)}
+    ${eval _objects := ${foreach _s,$($(1).drivers),$(_stageroot)${basename ${subst $($(1).prefix),,$(_s)}}$(builder.ext.obj)}}
+    # the launch command: for {compiled} it is the built binary; otherwise a per-suite override
+    # wins over the runner default, then the args
+    ${eval _base := ${if $($(1).runner.launch),$($(1).runner.launch),$(runner.$(_runner).launch)}}
+    ${eval _launch := ${if ${filter compiled,$(_prepare)},$(_binary) $($(1).argv),${strip $(_base) $(runner.$(_runner).argv) $($(1).argv)}}}
+    ${eval _env := ${strip $(runner.$(_runner).env) $($(1).env)}}
+    # the working directory: a {staged} runner runs from the staging area, everything else in place
     ${eval _workdir := ${if ${filter staged,$(_prepare)},$(_stageroot),$($(1).prefix)}}
+
+# for a {compiled} runner, build one binary from all the suite's sources
+${if ${filter compiled,$(_prepare)}, \
+    ${foreach _s,$($(1).drivers),${eval ${call test.runner.object,$(1),$(_s),$(_lang),$(_stageroot)}}} \
+    ${eval ${call test.runner.binary,$(1),$(_lang),$(_binary),$(_objects)}} \
+,}
 
 # the suite runs its runner once, after preparing the environment and before tearing it down
 $(1): $(1).post
@@ -115,9 +155,9 @@ $(1): $(1).post
 # startup
 $(1).pre: $($(1).pre)
 
-# prepare the environment according to the runner's {prepare} kind; for {staged}, mirror the suite
-# into the staging area and link the modules in as node_modules
-$(1).prepare: $($(1).prerequisites) $(1).pre
+# prepare the environment; for {staged}, mirror the suite into the staging area and link the
+# modules in as node_modules; for {compiled}, depend on the built binary
+$(1).prepare: $($(1).prerequisites) $(1).pre ${if ${filter compiled,$(_prepare)},$(_binary),}
 	@${call log.action,prepare,$(1)}
 	${if ${filter staged,$(_prepare)},@$(mkdirp) $(_stageroot) && $(cp.fr) $($(1).prefix). $(_stageroot)${if $($(1).stage.modules), && $(ln) -sfn $($(1).stage.modules) $(_stageroot)node_modules,},@true}
 
@@ -132,7 +172,7 @@ ${if $($(1).post),\
     ${eval $($(1).post) :: $(1).run} \
 }
 
-# clean up the staging area
+# clean up the staging area (objects and the binary live here too)
 $(1).clean::
 	@${call log.action,clean,$(1)}
 	@$(rm.force-recurse) $(_stageroot)

--- a/make/tests/rules.mm
+++ b/make/tests/rules.mm
@@ -91,7 +91,7 @@ endef
 #   usage: test.runner.object {testsuite} {source} {language} {stageroot}
 define test.runner.object =
     ${eval _obj := $(4)${basename ${subst $($(1).prefix),,$(2)}}$(builder.ext.obj)}
-$(_obj): $(2)
+$(_obj): $(2) | $($(1).prerequisites)
 	@${call log.action,$(3),${subst $($(1).home),,$(2)}}
 	@$(mkdirp) ${dir $(_obj)}
 	${call languages.compile,$(3),$(2),$(_obj),$(1).$(3) $(1) $($(1).extern)}
@@ -104,7 +104,7 @@ endef
 #   usage: test.runner.binary {testsuite} {language} {binary} {objects}
 define test.runner.binary =
 -include $(4:$(builder.ext.obj)=$(builder.ext.dep))
-$(3): $(4)
+$(3): $(4) $($(1).prerequisites)
 	@$(mkdirp) ${dir $(3)}
 	@${call log.action,link,${subst $($(1).home),,$(3)}}
 	${call languages.link,$(2),$(4),$(3),$(1).$(2) $(1) $($(1).extern)}

--- a/make/tests/rules.mm
+++ b/make/tests/rules.mm
@@ -48,7 +48,10 @@ ${foreach target, $($(1).staging.targets), \
     ${eval
         ${if $($(target).compiled),
             ${call test.workflows.target.compiled,$(target),$(1)}, \
-            ${call test.workflows.target.interpreted,$(target),$(1)} \
+            ${if $($(target).staged), \
+                ${call test.workflows.target.staged,$(target),$(1)}, \
+                ${call test.workflows.target.interpreted,$(target),$(1)} \
+            } \
         }
     }
 }
@@ -143,6 +146,105 @@ $(1).info:
 
 # just in case...
 .PHONY: $(1) $(1).cases $(1).clean
+
+# all done
+endef
+
+
+# build targets
+# target factory for a staged interpreted test case
+#
+# interpreted drivers normally run in place, from their spot in the source tree. that breaks down
+# for ESM (.mjs) drivers that import third-party packages: node resolves bare imports by walking
+# up from the driver's own directory looking for a {node_modules}, and we deliberately keep
+# {node_modules} out of the source tree -- it lives in the build staging area, where the web
+# client is assembled and webpack/vite/relay run. {NODE_PATH} is no help, since it is consulted
+# only by the legacy CommonJS loader, not by ESM.
+#
+# a suite opts in with
+#     <suite>.staged        := yes
+#     <suite>.stage.modules := <path to an existing node_modules>
+# and each driver is copied into a per-suite staging directory under the project tmpdir (outside
+# the source tree), with {stage.modules} symlinked in as {node_modules}; the driver then runs
+# from the staged copy, so the upward search reaches the modules. suites that leave {staged}
+# unset are unaffected.
+#
+#   usage: test.workflows.target.staged {target} {testsuite}
+define test.workflows.target.staged =
+
+    # local variables
+    ${eval _tag := ${subst $($(2).home),,$($(1).source)}}
+    ${eval _srcdir := ${dir $($(1).source)}}
+    ${eval _stageroot := $($(1).stage.prefix)}
+    ${eval _staged := $(_stageroot)${subst $($(2).prefix),,$($(1).source)}}
+    ${eval _stagedir := ${dir $(_staged)}}
+    ${eval _modules := $($(1).stage.modules)}
+    ${eval _launcher := $(compiler.$($(1).language)) $(_staged)}
+    ${eval _harness := ${if $($(1).harness),$($(1).harness) $(_launcher),$(_launcher)}}
+
+# the aggregator
+$(1): $(1).pre $(1).stage $(1).cases $(1).post
+
+# dependencies
+# startup
+$(1).pre: $($(1).pre)
+
+# cleanup
+$(1).post: $(1).pre $(1).cases $($(1).post)
+
+# make sure cleanup happens after startup; because this rule is in addition to its definition,
+# we must use a double colon; this in turn implies that the rule definition must be a
+# double-colon rule
+${if $($(1).post),\
+    ${eval $($(1).post) :: $($(1).pre) $(1).cases} \
+}
+
+# stage the driver alongside its neighbors and link in the modules
+$(1).stage: $(1).pre
+	@${call log.action,stage,$(_tag)}
+	@$(mkdirp) $(_stagedir)
+	@$(cp.fr) $(_srcdir). $(_stagedir)
+	@${if $(_modules),$(ln) -sfn $(_modules) $(_stageroot)node_modules,true}
+
+# invoking the driver for each registered test case, from the staging area
+$(1).cases: $($($(1).suite).prerequisites) $(1).pre $(1).stage
+	@$(cd) $(_stagedir) ; \
+        ${if $($(1).cases), \
+            ${foreach case, $($(1).cases), \
+                ${call log.action,test,$($(case).harness) $(_tag) $($(case).argv)}; \
+                $($(case).harness) $(_launcher) $($(case).argv); \
+                }, \
+	    ${call log.action,test,$(_tag)}; \
+                $($(1).harness) $(_launcher) $($(1).argv) \
+        }
+
+# clean up; double colon, since it may be used as a {post} rule
+$(1).clean::
+	@${if $($(1).clean), \
+            ${call log.action,clean,$(1)}; \
+            $(rm.force-recurse) ${addprefix $($(1).home),$($(1).clean)}, \
+        }
+	@$(rm.force-recurse) $(_stageroot)
+
+# show info
+$(1).info:
+	@${call log.sec,$(1),"a staged test driver in test suite '$(2)' of project '$($(2).project)'"}
+	@${call log.var,source,$($(1).source)}
+	@${call log.var,interpreted,yes}
+	@${call log.var,staged,yes}
+	@${call log.var,language,$($(1).language)}
+	@${call log.var,compiler,$(compiler.$($(1).language))}
+	@${call log.var,staged source,$(_staged)}
+	@${call log.var,modules,$(_modules)}
+	@${call log.sec,$(log.indent)cases,}
+	@${if $($(1).cases), \
+            ${foreach case,$($(1).cases),\
+                ${call log.var,$(log.indent)$(case),${strip \
+                    $($(case).harness) $(_launcher) $($(case).argv)}};}, \
+            $(log) $(log.indent)$(log.indent)$($(1).harness) $(_launcher) $($(1).argv)}
+
+# just in case...
+.PHONY: $(1) $(1).stage $(1).cases $(1).clean
 
 # all done
 endef

--- a/make/tests/rules.mm
+++ b/make/tests/rules.mm
@@ -19,8 +19,11 @@ tests.info: mm.banner
 # make the test suite specific targets
 #  usage: test.workflows {test suite}
 define tests.workflows =
-    # build recipes
-    ${call test.workflows.build,$(1)}
+    # build recipes: a single self-discovering runner, or the per-driver workflow
+    ${if $($(1).runner), \
+        ${call test.workflows.runner,$(1)}, \
+        ${call test.workflows.build,$(1)} \
+    }
     # info recipes: show values
     ${call test.workflows.info,$(1)}
     # help recipes: show documentation
@@ -79,6 +82,72 @@ ${foreach case,$($(1).staging.targets), \
     ${eval ${call test.workflows.aliases,$(1),$(case)} \
     } \
 }
+
+# all done
+endef
+
+
+# build targets
+# target factory for a runner suite: rather than enumerating per-file drivers, mm prepares the
+# environment a self-discovering test runner needs (playwright, vitest, pytest, ...) and invokes
+# it once, treating the process exit code as the verdict. the runner owns discovery, parallelism,
+# fixtures, and -- for browser runners -- the servers under test
+#   usage: test.workflows.runner {testsuite}
+define test.workflows.runner =
+
+    # resolve the runner and how it wants the environment prepared
+    ${eval _runner := $($(1).runner)}
+    ${if $(runner.$(_runner).prepare),,${error unknown test runner '$(_runner)' in suite '$(1)'}}
+    ${eval _prepare := $(runner.$(_runner).prepare)}
+    # the launch command: a per-suite override wins over the runner default, then the args
+    ${eval _base := ${if $($(1).runner.launch),$($(1).runner.launch),$(runner.$(_runner).launch)}}
+    ${eval _launch := ${strip $(_base) $(runner.$(_runner).argv) $($(1).argv)}}
+    ${eval _env := ${strip $(runner.$(_runner).env) $($(1).env)}}
+    # a {staged} runner runs from the staging area that carries the node_modules; everything else
+    # runs in place, in the suite directory
+    ${eval _stageroot := $($(1).stage.prefix)}
+    ${eval _workdir := ${if ${filter staged,$(_prepare)},$(_stageroot),$($(1).prefix)}}
+
+# the suite runs its runner once, after preparing the environment and before tearing it down
+$(1): $(1).post
+	@${call log.asset,"test suite",$(1)}
+
+# startup
+$(1).pre: $($(1).pre)
+
+# prepare the environment according to the runner's {prepare} kind; for {staged}, mirror the suite
+# into the staging area and link the modules in as node_modules
+$(1).prepare: $($(1).prerequisites) $(1).pre
+	@${call log.action,prepare,$(1)}
+	${if ${filter staged,$(_prepare)},@$(mkdirp) $(_stageroot) && $(cp.fr) $($(1).prefix). $(_stageroot)${if $($(1).stage.modules), && $(ln) -sfn $($(1).stage.modules) $(_stageroot)node_modules,},@true}
+
+# invoke the runner once, from the prepared working directory; its exit code decides pass/fail
+$(1).run: $(1).prepare
+	@${call log.action,$(_runner),$(1)}
+	@$(cd) $(_workdir) ; $(_env) $(_launch)
+
+# teardown
+$(1).post: $(1).run $($(1).post)
+${if $($(1).post),\
+    ${eval $($(1).post) :: $(1).run} \
+}
+
+# clean up the staging area
+$(1).clean::
+	@${call log.action,clean,$(1)}
+	@$(rm.force-recurse) $(_stageroot)
+
+# show info
+$(1).info.runner:
+	@${call log.sec,$(1),"a runner suite in project '$($(1).project)'"}
+	@${call log.var,runner,$(_runner)}
+	@${call log.var,prepare,$(_prepare)}
+	@${call log.var,launch,$(_launch)}
+	@${call log.var,workdir,$(_workdir)}
+	@${call log.var,modules,$($(1).stage.modules)}
+
+# just in case...
+.PHONY: $(1) $(1).pre $(1).prepare $(1).run $(1).post $(1).clean
 
 # all done
 endef

--- a/mm
+++ b/mm
@@ -1559,6 +1559,7 @@ class Builder(pyre.application, family="pyre.applications.mm", namespace="mm"):
         # the mapping from mm extern name to conda package name(s); try names in order
         packages = {
             "cantera": ["cantera"],
+            "catch2": ["catch2"],
             "cgal": ["cgal"],
             "cspice": ["cspice", "naif-cspice"],
             "cuda": ["cuda-toolkit", "cudatoolkit", "cuda"],

--- a/mm
+++ b/mm
@@ -1815,6 +1815,7 @@ class Builder(pyre.application, family="pyre.applications.mm", namespace="mm"):
         # python-versioned ports use {pyTag} e.g. "312" for python 3.12
         packages = {
             "cantera": ["cantera"],
+            "catch2": ["catch2"],
             "cgal": ["cgal5", "cgal"],
             "cspice": ["cspice"],
             "eigen": ["eigen3"],
@@ -2013,6 +2014,8 @@ class Builder(pyre.application, family="pyre.applications.mm", namespace="mm"):
         # the mapping from mm extern name to dpkg package name(s); try names in order
         packages = {
             "cantera": ["libcantera-dev"],
+            # libcatch2-dev ships v3 with libraries on Ubuntu 25.10+ / Debian trixie+
+            "catch2": ["libcatch2-dev"],
             "cgal": ["libcgal-dev"],
             "cspice": ["libcspice-dev"],
             "eigen": ["libeigen3-dev"],


### PR DESCRIPTION
Motivated by work on setting up a test suite for `qed` (https://guthub.com/aivazis/qed), this PR adds support for test runners that go beyond single drivers. Added support for the following:

- catch2
- gtest
- pytest
- playwright
- vitest

for C/C++, python, and javascript test drivers.