### PR TITLE
Add an openmp build variant (#16)

### DIFF
--- a/make/compilers/clang/clang++.mm
+++ b/make/compilers/clang/clang++.mm
@@ -40,6 +40,8 @@ clang++.opt := -O3
 clang++.cov := --coverage
 clang++.prof := -pg
 clang++.shared := -fPIC
+# openmp support
+clang++.openmp := -fopenmp
 
 # language level
 clang++.std.c++11 := -std=c++11

--- a/make/compilers/clang/clang.mm
+++ b/make/compilers/clang/clang.mm
@@ -34,6 +34,8 @@ clang.reldeb := -Og -fno-omit-frame-pointer
 clang.cov := --coverage
 clang.prof := -pg
 clang.shared := -fPIC
+# openmp support
+clang.openmp := -fopenmp
 
 # language level
 clang.std.ansi := -ansi

--- a/make/compilers/clang/flang.mm
+++ b/make/compilers/clang/flang.mm
@@ -38,6 +38,8 @@ flang.cov := --coverage
 # VERIFY: gprof-style -pg has limited support in LLVM Fortran; may silently do nothing
 flang.prof := -pg
 flang.shared := -fPIC
+# openmp support
+flang.openmp := -fopenmp
 
 # language level
 # VERIFY: all std flags below; they mirror gfortran but flang-new may differ

--- a/make/compilers/cython.mm
+++ b/make/compilers/cython.mm
@@ -22,6 +22,8 @@ cython.opt :=
 cython.cov :=
 cython.prof :=
 cython.shared :=
+# openmp belongs to the C compiler that builds the generated source, not to {cython}
+cython.openmp :=
 
 
 # end of file

--- a/make/compilers/gcc/g++.mm
+++ b/make/compilers/gcc/g++.mm
@@ -34,6 +34,8 @@ g++.opt := -O3
 g++.cov := --coverage
 g++.prof := -pg
 g++.shared := -fPIC
+# openmp support
+g++.openmp := -fopenmp
 
 # language level
 g++.std.c++11 := -std=c++11

--- a/make/compilers/gcc/gcc.mm
+++ b/make/compilers/gcc/gcc.mm
@@ -34,6 +34,8 @@ gcc.opt := -O3
 gcc.cov := --coverage
 gcc.prof := -pg
 gcc.shared := -fPIC
+# openmp support
+gcc.openmp := -fopenmp
 
 # language level
 gcc.std.ansi := -ansi

--- a/make/compilers/gcc/gfortran.mm
+++ b/make/compilers/gcc/gfortran.mm
@@ -33,6 +33,8 @@ gfortran.opt := -O3
 gfortran.cov := -coverage
 gfortran.prof := -pg
 gfortran.shared := -fPIC
+# openmp support
+gfortran.openmp := -fopenmp
 
 # language level
 gfortran.std.f77 :=

--- a/make/compilers/intel/c++.mm
+++ b/make/compilers/intel/c++.mm
@@ -40,6 +40,8 @@ intel++.opt := -O3
 intel++.cov := --coverage
 intel++.prof := -pg
 intel++.shared := -fPIC
+# openmp support
+intel++.openmp := -qopenmp
 
 # language level
 intel++.std.c++11 := -std=c++11

--- a/make/compilers/intel/c.mm
+++ b/make/compilers/intel/c.mm
@@ -34,6 +34,8 @@ intel.reldeb := -g -O
 intel.cov := --coverage
 intel.prof := -pg
 intel.shared := -fPIC
+# openmp support
+intel.openmp := -qopenmp
 
 # language level
 intel.std.ansi := -ansi

--- a/make/compilers/intel/fortran.mm
+++ b/make/compilers/intel/fortran.mm
@@ -33,6 +33,8 @@ ifx.opt := -O3 -xHost
 ifx.cov := -profile-functions -profile-loops=all
 ifx.prof := -pg
 ifx.shared := -fPIC
+# openmp support
+ifx.openmp := -qopenmp
 
 # language level
 ifx.std.f77 :=

--- a/make/compilers/nvcc/nvcc.mm
+++ b/make/compilers/nvcc/nvcc.mm
@@ -37,6 +37,8 @@ nvcc.opt := -O3
 nvcc.cov := --coverage
 nvcc.prof := -pg
 nvcc.shared := -Xcompiler -fPIC
+# openmp support; hand the switch to the host compiler
+nvcc.openmp := -Xcompiler -fopenmp
 
 # language level
 nvcc.std.c++03 := --std=c++03

--- a/make/targets/openmp.mm
+++ b/make/targets/openmp.mm
@@ -1,0 +1,21 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# meta-data
+targets.openmp.description := compiling and linking with OpenMP enabled
+
+# initialize
+${eval ${call target.init,openmp}}
+
+# adjust: the OpenMP switch belongs on both the compile and the link command lines, so that
+# the compiler enables the {_OPENMP} guard and the driver pulls in the OpenMP runtime
+${call target.adjust,openmp,$(languages.compiled),flags ldflags}
+
+# build my info target
+${eval ${call target.info.flags,openmp}}
+
+
+# end of file


### PR DESCRIPTION
Closes #16.

Adds `openmp` as a build-target variant. `mm --target=...,openmp` enables OpenMP by putting the compiler's OpenMP switch on **both** the compile and the link command lines (same shape as the `debug` variant, via `target.adjust,openmp,$(languages.compiled),flags ldflags`).

- **compile side** — enables the OpenMP directives and defines `_OPENMP`
- **link side** — lets the driver auto-link the OpenMP runtime: libgomp for gcc, libomp for clang, plus `-pthread`. No explicit `-lgomp`/`-lomp` needed (confirmed against the [GNU libgomp](https://gcc.gnu.org/onlinedocs/libgomp/Enabling-OpenMP.html) and [Clang OpenMP](https://clang.llvm.org/docs/OpenMPSupport.html) docs — the flag "arranges for automatic linking of the OpenMP runtime library", but only when it's on the link line, which is why it's in `ldflags`).

### Per-compiler switch
| compiler | flag |
|---|---|
| clang / clang++ / flang, gcc / g++ / gfortran | `-fopenmp` |
| intel (icx) / intel++ / ifx | `-qopenmp` |
| nvcc | `-Xcompiler -fopenmp` |
| cython | _(empty — the generated C carries it)_ |

`openmp` joins the build-variant tag (e.g. `openmp-opt-shared-darwin-arm64`), so OpenMP builds get their own tree.

### Test plan
- `mm --target=opt,shared,openmp targets.openmp.info` → c++ shows `flags = -fopenmp`, `ldflags = -fopenmp`.
- Verbose build of `examples/simple` (conda clang): `-fopenmp` appears on the compile lines and on the `-dynamiclib … .so` link line; links cleanly against the conda libomp; no new warnings.
- Not yet exercised on a real gcc / nvcc / Intel toolchain — worth a smoke test there before relying on it.