### PR TITLE
toolchains: environment-level developer tool support (first: playwright)

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,34 @@ of installed packages and uses it to resolve external dependencies
 automatically.
 
 
+## Developer toolchains
+
+Some projects depend on external developer tools — a browser-automation runner,
+a bundler, a linter — that are heavy, version-sensitive, and naturally shared
+across every build of an environment rather than owned by any one project. mm
+installs these as **toolchains**: once per environment, at a shared location
+keyed by the active conda environment (`~/tools/mm/$CONDA_DEFAULT_ENV/toolchains`
+by default, overridable with `--toolchains`). Because the location tracks the
+environment and not the build variant, a toolchain is reused across every build
+context and is never disturbed by `mm clean`.
+
+A project declares the tools it uses; it never installs or reinstalls them. The
+lifecycle is driven from the command line:
+
+```
+mm toolchains          # list the available toolchains and the shared root
+mm playwright.install  # fetch and install one (a deliberate, online action)
+mm playwright.verify   # check it is present; fails a build if it is missing
+mm playwright.info     # show its pinned version and location
+mm playwright.clean    # remove the installation
+```
+
+Builds and tests only **verify** that a toolchain is present — they never reach
+the network. If a required tool is missing, the build stops with a one-line
+instruction to install it. Installation is always an explicit, deliberate step,
+so an offline build never surprises you by trying to download anything.
+
+
 ## Portability
 
 Every C++ source file in an mm project begins with:

--- a/docs/command-line-reference.md
+++ b/docs/command-line-reference.md
@@ -147,6 +147,12 @@ conda environment with a versioned site-packages).
 : Additional paths to add to make's include path. Useful for injecting
   site-specific make fragments without modifying the project configuration.
 
+`--toolchains=PATH` (trait: `toolchains`)
+: Root directory for environment-level developer toolchains (e.g. playwright).
+  Defaults to `~/tools/mm/$CONDA_DEFAULT_ENV/toolchains`, keyed by the active
+  environment so a toolchain is shared across every build context rather than
+  tied to a build variant. See *Developer toolchains* in the README.
+
 `--color=yes|no`
 : Enable or disable colorised output. Default: `yes` on terminals that support
   it.

--- a/etc/bash_completion/mm
+++ b/etc/bash_completion/mm
@@ -55,6 +55,7 @@ tests.info
 docker-images.info
 webpack.info
 vite.info
+toolchains.info
 "
 
 # =============================================================================
@@ -272,6 +273,7 @@ _comp_cmd_mm__get_target_description()
         docker-images.info)  echo "List known docker images" ;;
         webpack.info)        echo "List known webpack bundles" ;;
         vite.info)           echo "List known vite bundles" ;;
+        toolchains.info)     echo "List environment-level developer toolchains" ;;
 
         # --- Per-asset suffix descriptions ---
         *.directories)       echo "Create required directories" ;;
@@ -336,6 +338,9 @@ _comp_cmd_mm__get_target_description()
         *.stage.files)       echo "Stage source files" ;;
         *.stage.modules)     echo "Install/update node modules" ;;
         *.staging.prefix)    echo "Create staging area" ;;
+        *.install)           echo "Install (toolchain or ux bundle)" ;;
+        *.verify)            echo "Verify a toolchain is present" ;;
+        *.update)            echo "Update a toolchain to its pinned version" ;;
         *.info.files)        echo "List source files" ;;
         *.info.staged.files) echo "List staged files" ;;
         *.info.staged.directories) echo "List staged directories" ;;
@@ -830,6 +835,35 @@ _comp_cmd_mm__get_extern_targets()
 }
 
 # =============================================================================
+# Developer toolchain discovery
+# =============================================================================
+
+# Scan the mm installation's make/toolchains/ directory to find available developer
+# toolchains and generate <tool>.{install,update,verify,info,clean} targets
+# @return List of toolchain action targets
+_comp_cmd_mm__get_toolchain_targets()
+{
+    local mm_home
+    mm_home=$(_comp_cmd_mm__find_mm_home)
+
+    [[ -z "$mm_home" ]] && return
+
+    local tc_dir="$mm_home/make/toolchains"
+    [[ ! -d "$tc_dir" ]] && return
+
+    for tool_dir in "$tc_dir"/*/; do
+        [[ ! -d "$tool_dir" ]] && continue
+        local tool
+        tool=$(basename "$tool_dir")
+        echo "$tool.install"
+        echo "$tool.update"
+        echo "$tool.verify"
+        echo "$tool.info"
+        echo "$tool.clean"
+    done
+}
+
+# =============================================================================
 # Dynamic target variant info targets
 # =============================================================================
 
@@ -974,6 +1008,13 @@ _comp_cmd_mm__get_all_targets()
     language_targets=$(_comp_cmd_mm__get_language_targets)
     if [[ -n "$language_targets" ]]; then
         targets="$targets $(echo "$language_targets" | tr '\n' ' ')"
+    fi
+
+    # 9. Developer toolchain action targets (from mm installation)
+    local toolchain_targets
+    toolchain_targets=$(_comp_cmd_mm__get_toolchain_targets)
+    if [[ -n "$toolchain_targets" ]]; then
+        targets="$targets $(echo "$toolchain_targets" | tr '\n' ' ')"
     fi
 
     echo "$targets"

--- a/etc/zsh_completion/_mm
+++ b/etc/zsh_completion/_mm
@@ -68,6 +68,7 @@ typeset -a _mm_global_target_specs=(
     'docker-images.info:List known docker images'
     'webpack.info:List known webpack bundles'
     'vite.info:List known vite bundles'
+    'toolchains.info:List environment-level developer toolchains'
 )
 
 # =============================================================================
@@ -820,6 +821,29 @@ _mm_complete_extern_targets() {
     (( ${#specs} )) && _describe -t extern-targets 'extern package target' specs
 }
 
+# Generate <tool>.{install,update,verify,info,clean} targets from make/toolchains/
+_mm_complete_toolchain_targets() {
+    local mm_home
+    mm_home="$(_mm_find_mm_home)"
+    [[ -z "$mm_home" ]] && return 1
+
+    local tc_dir="$mm_home/make/toolchains"
+    [[ ! -d "$tc_dir" ]] && return 1
+
+    local specs=()
+    local tool_dir tool
+    for tool_dir in "$tc_dir"/*(N/); do
+        tool="${tool_dir:t}"
+        specs+=("${tool}.install:Install the ${tool} toolchain")
+        specs+=("${tool}.update:Update the ${tool} toolchain")
+        specs+=("${tool}.verify:Verify the ${tool} toolchain is present")
+        specs+=("${tool}.info:Show ${tool} toolchain settings")
+        specs+=("${tool}.clean:Remove the ${tool} toolchain")
+    done
+
+    (( ${#specs} )) && _describe -t toolchain-targets 'toolchain target' specs
+}
+
 # Generate targets.{variant}.info targets from make/targets/
 _mm_complete_variant_targets() {
     local mm_home
@@ -916,6 +940,7 @@ mm-target-help() {
             docker-images.info)  echo "List known docker images" ;;
             webpack.info)        echo "List known webpack bundles" ;;
             vite.info)           echo "List known vite bundles" ;;
+            toolchains.info)     echo "List environment-level developer toolchains" ;;
             *.directories)       echo "Create required directories" ;;
             *.assets)            echo "Build all assets" ;;
             *.clean)             echo "Clean artifacts" ;;
@@ -978,6 +1003,9 @@ mm-target-help() {
             *.stage.files)       echo "Stage source files" ;;
             *.stage.modules)     echo "Install/update node modules" ;;
             *.staging.prefix)    echo "Create staging area" ;;
+            *.install)           echo "Install (toolchain or ux bundle)" ;;
+            *.verify)            echo "Verify a toolchain is present" ;;
+            *.update)            echo "Update a toolchain to its pinned version" ;;
             *.info.files)        echo "List source files" ;;
             *.info.staged.files) echo "List staged files" ;;
             *.info.staged.directories) echo "List staged directories" ;;
@@ -1074,6 +1102,7 @@ _mm() {
                 'extern-targets:extern package:_mm_complete_extern_targets' \
                 'variant-targets:variant info:_mm_complete_variant_targets' \
                 'language-targets:language info:_mm_complete_language_targets' \
+                'toolchain-targets:toolchain target:_mm_complete_toolchain_targets' \
                 && ret=0
             ;;
     esac

--- a/make/merlin.mm
+++ b/make/merlin.mm
@@ -21,7 +21,7 @@ config.db += ${if $(user.environment),$(user.environment) $(user.environment)@$(
 define model :=
     log mm
     languages platforms hosts users developers
-    compilers targets builder runners
+    compilers targets builder runners toolchains
 	extern projects
 endef
 

--- a/make/toolchains/init.mm
+++ b/make/toolchains/init.mm
@@ -1,0 +1,36 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# the location of the built-in toolchain definitions
+toolchains.mm ?= $(mm.home)/make/toolchains
+
+# the root under which toolchains get installed; the mm driver resolves this from the
+# {toolchains} trait, keyed by the active environment so the installation is shared across
+# every build context while still tracking where node and python come from; the fallback
+# mirrors the driver's formula from the same driver-supplied variables, covering a direct
+# {make} invocation that bypasses the driver
+toolchains.home ?= $(user.home)/tools/mm/$(user.environment)/toolchains
+
+
+# the toolchain constructor; fills in whatever a tool definition left unset and resolves the
+# installation directory under the shared root
+#   usage: toolchain.init {tool}
+define toolchain.init =
+    # the human readable description
+    ${eval toolchain.$(1).doc ?=}
+    # the ecosystem the tool belongs to; drives how the pin is stored and installed
+    ${eval toolchain.$(1).kind ?= node}
+    # the exact version to pin
+    ${eval toolchain.$(1).version ?=}
+    # the directory that holds both the installation and mm's configuration for the tool
+    ${eval toolchain.$(1).home := $(toolchains.home)/$(1)}
+    # the artifact whose presence proves the tool is installed and intact
+    ${eval toolchain.$(1).sentinel ?= $(toolchain.$(1).home)/node_modules/.bin/$(1)}
+# all done
+endef
+
+
+# end of file

--- a/make/toolchains/model.mm
+++ b/make/toolchains/model.mm
@@ -1,0 +1,20 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# the registry of known toolchains
+toolchains := playwright
+
+# load each tool's definition
+include ${foreach tool,$(toolchains),$(toolchains.mm)/$(tool)/$(tool).mm}
+
+# fill in defaults and resolve installation locations
+${foreach tool,$(toolchains),${eval ${call toolchain.init,$(tool)}}}
+
+# build the universal recipes for each tool
+${foreach tool,$(toolchains),${eval ${call toolchain.workflows,$(tool)}}}
+
+
+# end of file

--- a/make/toolchains/playwright/package.json
+++ b/make/toolchains/playwright/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "mm-toolchain-playwright",
+    "version": "1.60.0",
+    "private": true,
+    "description": "pinned playwright toolchain managed by mm",
+    "dependencies": {
+        "@playwright/test": "1.60.0"
+    }
+}

--- a/make/toolchains/playwright/playwright.mm
+++ b/make/toolchains/playwright/playwright.mm
@@ -1,0 +1,34 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# playwright: a node-based end-to-end browser-automation toolchain; it is installed once per
+# environment and owns its own browser binaries, so a project's test suite never reinstalls it
+toolchain.playwright.doc := "node end-to-end browser automation; owns its browsers"
+toolchain.playwright.kind := node
+toolchain.playwright.version := 1.60.0
+
+# the location of the browser binaries; keeping them inside the toolchain makes the install
+# self-contained, so {playwright.clean} removes everything and environments cannot drift
+toolchain.playwright.browsers = $(toolchain.playwright.home)/browsers
+
+
+# install the toolchain: stage the pinned manifest, fetch the framework, then the browsers
+playwright.install:
+	@${call log.sec,"playwright","installing the playwright toolchain $(toolchain.playwright.version)"}
+	@${call log.action,"mkdir",$(toolchain.playwright.home)}
+	$(mkdirp) $(toolchain.playwright.home)
+	@${call log.action,"stage","package.json"}
+	$(cp) $(toolchains.mm)/playwright/package.json $(toolchain.playwright.home)/package.json
+	@${call log.action,"npm","install"}
+	$(cd) $(toolchain.playwright.home) && npm install
+	@${call log.action,"playwright","browsers"}
+	$(cd) $(toolchain.playwright.home) && PLAYWRIGHT_BROWSERS_PATH=$(toolchain.playwright.browsers) npx playwright install chromium
+
+# update the toolchain: re-stage the pinned manifest and refresh the framework and browsers
+playwright.update: playwright.install
+
+
+# end of file

--- a/make/toolchains/rules.mm
+++ b/make/toolchains/rules.mm
@@ -1,0 +1,55 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# the toolchain registry summary
+toolchains.info:
+	@${call log.sec,"toolchains","environment-level developer tools installed once per environment"}
+	@${call log.sec,"  location",}
+	@${call log.var,"root",$(toolchains.home)}
+	@${call log.sec,"  available tools",}
+	@${foreach tool,$(toolchains),${call log.var,$(tool),$(toolchain.$(tool).doc)};}
+	@${call log.sec,"  actions",}
+	@${call log.help,"<tool>.install","fetch and install it (a deliberate online action)"}
+	@${call log.help,"<tool>.verify","check it is present; fails a build if it is missing"}
+	@${call log.help,"<tool>.update","reinstall it against the pinned version"}
+	@${call log.help,"<tool>.info","show its settings"}
+	@${call log.help,"<tool>.clean","remove the installation"}
+
+
+# make the universal recipes every toolchain provides: info, verify, clean; the install and
+# update recipes are ecosystem specific and live in each tool's own definition
+#  usage: toolchain.workflows {tool}
+define toolchain.workflows =
+
+# report this tool's settings
+$(1).info:
+	@${call log.sec,$(1),$(toolchain.$(1).doc)}
+	@${call log.var,kind,$(toolchain.$(1).kind)}
+	@${call log.var,version,$(toolchain.$(1).version)}
+	@${call log.var,home,$(toolchain.$(1).home)}
+	@${call log.var,sentinel,$(toolchain.$(1).sentinel)}
+
+# confirm the tool is installed; if it isn't, fail with a one-line instruction so a build that
+# depends on it stops with an actionable message instead of a cryptic error further downstream
+$(1).verify:
+	@test -e "$(toolchain.$(1).sentinel)" || ( \
+	    ${call log.error,"the '$(1)' toolchain is not installed"} ; \
+	    ${call log.info,"expected it under $(toolchain.$(1).home)"} ; \
+	    ${call log.info,"install it with: mm $(1).install"} ; \
+	    exit 1 \
+	)
+	@${call log.action,"verify","$(1) $(toolchain.$(1).version) is available"}
+
+# remove the entire installation so the next install starts from a clean slate
+$(1).clean:
+	@${call log.action,"rm",$(toolchain.$(1).home)}
+	$(rm.force-recurse) $(toolchain.$(1).home)
+
+# all done
+endef
+
+
+# end of file

--- a/mm
+++ b/mm
@@ -134,6 +134,12 @@ class Builder(pyre.application, family="pyre.applications.mm", namespace="mm"):
     bldroot.default = None
     bldroot.doc = "the path to the intermediate build products"
 
+    toolchains = pyre.properties.path()
+    toolchains.default = None
+    toolchains.doc = (
+        "the directory where environment-level developer toolchains are installed"
+    )
+
     target = pyre.properties.strings()
     target.default = ["debug", "shared"]
     target.doc = "the list of target variants to build"
@@ -353,6 +359,8 @@ class Builder(pyre.application, family="pyre.applications.mm", namespace="mm"):
         self._bldTag = None
         # and the install directory
         self._prefix = None
+        # the directory with the environment-level developer toolchains
+        self._toolchains = None
         # the python package installation directory; may be overridden by mode-specific logic
         self._pycPrefix = None
         # the syntax dispatch table: maps shell names to (var, value) -> export/unset statement
@@ -615,6 +623,8 @@ class Builder(pyre.application, family="pyre.applications.mm", namespace="mm"):
         self._bldroot = self.locateBuildRoot()
         # figure out the install directory
         self._prefix = self.locatePrefix()
+        # figure out where the environment-level developer toolchains live
+        self._toolchains = self.locateToolchains()
         # adjust my environment variables with the build configuration
         self.updateEnvironmentVariables()
         # all done
@@ -974,6 +984,23 @@ class Builder(pyre.application, family="pyre.applications.mm", namespace="mm"):
         """
         return self._prefixDispatch[self.mode]()
 
+    def locateToolchains(self):
+        """
+        Figure out where environment-level developer toolchains are installed; the location is
+        keyed by the active environment rather than the build context, so a toolchain is shared
+        across every build variant while still tracking where node and python come from
+        """
+        # if the user has expressed an opinion
+        if self.toolchains is not None:
+            # use it
+            return self.toolchains
+        # otherwise anchor on a per-environment directory under the user's tools tree
+        base = pyre.primitives.path("~/tools/mm").expanduser()
+        # get the active environment
+        env = self.environment
+        # and fold it the environment name, when there is one
+        return base / env / "toolchains" if env else base / "toolchains"
+
     def deduceCompilerSuite(self):
         """
         Look through the set of {compilers} to deduce the name of the compiler suite that
@@ -1275,7 +1302,15 @@ class Builder(pyre.application, family="pyre.applications.mm", namespace="mm"):
         traits the user actually set on the command line are emitted
         """
         # the path-determining traits; this set has been stable for years and is cheap to extend
-        for name in ("mode", "bldroot", "prefix", "tag", "environment", "compilers", "target"):
+        for name in (
+            "mode",
+            "bldroot",
+            "prefix",
+            "tag",
+            "environment",
+            "compilers",
+            "target",
+        ):
             # the child reconstructs config-file, environment, and default values by itself
             if not self._fromCommandLine(name):
                 continue
@@ -1309,6 +1344,8 @@ class Builder(pyre.application, family="pyre.applications.mm", namespace="mm"):
         yield f"mm.merlin={self._makefile}"
         # the location of the built-in package database
         yield f"mm.extern={self.engine / 'extern'}"
+        # the root of the environment-level developer toolchains
+        yield f"toolchains.home={self._toolchains}"
         # the package manager
         yield f"mm.pkgdb={self.pkgdb}"
         # the list of compilers
@@ -1764,7 +1801,9 @@ class Builder(pyre.application, family="pyre.applications.mm", namespace="mm"):
             # unpack the record
             version, build, record = index[candidate]
             # trim to major.minor for packages that key interpreter names and paths off it
-            mmVersion = self._condaMajorMinor(version) if recipe.get("trim") else version
+            mmVersion = (
+                self._condaMajorMinor(version) if recipe.get("trim") else version
+            )
             # the entry, ready for any package-specific configuration lines
             entry = {
                 "name": name,
@@ -1851,6 +1890,7 @@ class Builder(pyre.application, family="pyre.applications.mm", namespace="mm"):
         compiler or linker fail later. Returns a database entry, or None if cuda is absent or
         unusable
         """
+
         # a package family is present if any installed package starts with the stem; conda-forge
         # ships cuda as cross-arch umbrellas ({cuda-nvcc}) that depend on arch-specific splits
         # ({cuda-nvcc_linux-64}), and the umbrella is what the user installs
@@ -1929,7 +1969,9 @@ class Builder(pyre.application, family="pyre.applications.mm", namespace="mm"):
             # what happened
             warning.line(f"cuda is installed in '{prefix}' but cuda.h was not found")
             # the consequence
-            warning.line("falling back to the environment prefix; the include path may be wrong")
+            warning.line(
+                "falling back to the environment prefix; the include path may be wrong"
+            )
             # flush
             warning.log()
             # the conservative fallback
@@ -2384,7 +2426,9 @@ class Builder(pyre.application, family="pyre.applications.mm", namespace="mm"):
         if result.returncode != 0:
             return []
         # each non-empty line is an absolute path owned by the package
-        return [pyre.primitives.path(line) for line in result.stdout.splitlines() if line]
+        return [
+            pyre.primitives.path(line) for line in result.stdout.splitlines() if line
+        ]
 
     def _dpkgAnchor(self, path, prefix):
         """
@@ -2530,7 +2574,9 @@ class Builder(pyre.application, family="pyre.applications.mm", namespace="mm"):
                 # use it
                 return executable
         # otherwise fall back to a {PATH} search, preferring micromamba
-        return shutil.which("micromamba") or shutil.which("mamba") or shutil.which("conda")
+        return (
+            shutil.which("micromamba") or shutil.which("mamba") or shutil.which("conda")
+        )
 
     def _condaPrefix(self):
         """
@@ -2547,7 +2593,9 @@ class Builder(pyre.application, family="pyre.applications.mm", namespace="mm"):
             channel = journal.error("mm.conda")
             # complain
             channel.line("no conda agent found")
-            channel.line("set $MAMBA_EXE or $CONDA_EXE, or put micromamba/mamba/conda on PATH")
+            channel.line(
+                "set $MAMBA_EXE or $CONDA_EXE, or put micromamba/mamba/conda on PATH"
+            )
             # flush
             channel.log()
             # and bail, in case errors aren't fatal


### PR DESCRIPTION
## Summary

Adds a **toolchain** abstraction to mm: an environment-level developer tool —
heavy, version-pinned, and shared across every build of an environment rather
than owned by any one project. The first toolchain is **playwright**. A project
*declares* the tools it uses; it never installs or reinstalls them.

This is motivated by the qed `qed.ux.playwright` suite, whose framework
`node_modules` currently lives under a per-build-context staging dir and so is
lost on every new build context (and was wiped by an `mm clean`). A toolchain
decouples tool presence from the build context, which fixes that whole class of
fragility. (The qed rewire onto this is a follow-up, not in this PR.)

## Design

- **Installed once per environment, at a shared location.** The root is keyed by
  the active conda environment — `~/tools/mm/$CONDA_DEFAULT_ENV/toolchains` by
  default — so it is environment-aware (where node/python come from) but **not**
  tied to a build variant. A toolchain is therefore reused across every build
  context and is never disturbed by `mm clean`.
- **Offline-safe builds.** Build/test targets only **verify** a toolchain is
  present; if it is missing they fail with a one-line install instruction and
  never touch the network. `install` / `update` / `clean` are explicit,
  deliberate CLI actions.
- **Pin, but no committed lockfile.** mm ships only the exact-pinned
  `package.json`. A `package-lock.json` is resolved against a specific node/npm
  and platform, so it is an artifact of an *environment*, not of mm — committing
  one would go stale the moment a conda update brings a new node. Each
  environment generates and keeps its own lock in the toolchain home alongside
  its `node_modules`.

## CLI surface

```
mm toolchains          # list available toolchains and the shared root
mm playwright.install  # fetch and install (a deliberate, online action)
mm playwright.verify   # check it is present; fails a build if missing
mm playwright.update   # reinstall against the pinned version
mm playwright.info     # show pinned version and location
mm playwright.clean    # remove the installation
```

## Changes

**make side** (`3e777ee`)
- `make/toolchains/{init,rules,model}.mm` — the toolchain framework, parallel to
  externals: location resolution, the `toolchain.init` constructor, the
  `toolchains.info` registry screen, and the universal `info`/`verify`/`clean`
  recipe generator.
- `make/toolchains/playwright/` — the playwright definition (pinned `1.60.0`,
  browsers kept under the toolchain dir) plus the ecosystem-specific
  `install`/`update` recipes and the pinned `package.json`.
- `make/merlin.mm` — registers `toolchains` as a model class.
- `etc/bash_completion/mm`, `etc/zsh_completion/_mm` — `toolchains.info` and the
  per-tool action targets, discovered from `make/toolchains/*/`.
- `README.md`, `docs/command-line-reference.md` — a "Developer toolchains"
  section and the `--toolchains` option.

**driver side** (`f9cc0f9`)
- A new `toolchains` trait on the `mm` driver, resolved by `locateToolchains()`
  to the env-keyed root and emitted to the make engine as `toolchains.home`
  (the make side keeps a fallback that re-derives the same value, mirroring the
  `mm.extern` convention).

## Testing

All `mm playwright.*` targets exercised and working: `toolchains.info`,
`playwright.{info,install,verify,update,clean}`. `verify` correctly fails a build
(non-zero exit, actionable message) when the toolchain is absent and passes once
installed. Both completion scripts pass `bash -n` / `zsh -n` and emit the right
targets.
