### PR TITLE
Use playwright as an example toolchain member and test runner

### DIFF
--- a/make/runners/playwright.mm
+++ b/make/runners/playwright.mm
@@ -8,9 +8,12 @@
 # a staging area; it discovers its own specs and starts servers through playwright.config.ts, so
 # serial vs parallel routing and server fixtures are its concern, not ours
 runner.playwright.prepare := staged
-runner.playwright.launch := npx playwright test
+# invoke the executable directly rather than through {npx}: with the toolchain's {node_modules/.bin}
+# on {PATH}, {playwright} resolves to the installed binary, and a missing one fails loudly instead
+# of {npx} silently fetching a copy from the network
+runner.playwright.launch := playwright test
 runner.playwright.doc := "node end-to-end runner; owns the browsers and the servers under test"
-runner.playwright.suite := "stage.modules: the ux bundle's node_modules"
+runner.playwright.suite := "toolchain: declare {playwright} so mm wires NODE_PATH, PATH, and browsers"
 
 
 # end of file

--- a/make/tests/init.mm
+++ b/make/tests/init.mm
@@ -21,6 +21,12 @@ define tests.init =
     # the stem for generating test suite specific names
     ${eval $(2).stem ?= $($(1).stem)}
 
+    # the environment-level toolchains this suite uses, if any; opt-in and empty by default, so a
+    # suite that names none is untouched. mm verifies each is installed before the suite runs and
+    # folds its consumer interface (node_modules onto NODE_PATH, plus any tool specific env) into
+    # the runner invocation, scoped to this suite
+    ${eval $(2).toolchain ?=}
+
     # if set, the suite delegates to a self-discovering test runner (playwright, vitest, ...)
     # instead of mm enumerating per-file drivers
     ${eval $(2).runner ?=}
@@ -97,7 +103,7 @@ define tests.init =
     $(2).metadoc.artifacts := "information about the test cases"
 
     # category documentation
-    $(2).meta.general := project stem name
+    $(2).meta.general := project stem name toolchain
     $(2).meta.extern := extern.requested extern.supported extern.available
     $(2).meta.artifacts := root prefix runner staged stage.prefix stage.modules
 
@@ -106,6 +112,7 @@ define tests.init =
     $(2).metadoc.project := "the name of the project to which this test suite belongs"
     $(2).metadoc.name := "the name of the test suite"
     $(2).metadoc.stem := "the stem for generating test suite specific names"
+    $(2).metadoc.toolchain := "the environment-level toolchains this suite uses (opt-in)"
     # dependencies
     $(2).metadoc.extern.requested := "requested dependencies"
     $(2).metadoc.extern.supported := "the dependencies for which there is mm support"

--- a/make/tests/rules.mm
+++ b/make/tests/rules.mm
@@ -141,7 +141,19 @@ define test.workflows.runner =
     # wins over the runner default, then the args
     ${eval _base := ${if $($(1).runner.launch),$($(1).runner.launch),$(runner.$(_runner).launch)}}
     ${eval _launch := ${if ${filter compiled,$(_prepare)},$(_binary) $($(1).argv),${strip $(_base) $(runner.$(_runner).argv) $($(1).argv)}}}
-    ${eval _env := ${strip $(runner.$(_runner).env) $($(1).env)}}
+    # the toolchains this suite opted into, if any; fold each one's consumer interface into the
+    # runner environment: {node} tools contribute their {node_modules} to a single {NODE_PATH} -- a
+    # list, so several tools coexist without colliding -- plus whatever extra environment each tool
+    # needs to be found (e.g. a browser path). this is scoped to the suite launch, so a project that
+    # does not opt in is untouched
+    ${eval _tools := $($(1).toolchain)}
+    ${eval _modules := ${strip ${foreach _t,$(_tools),$(toolchain.$(_t).modules)}}}
+    ${eval _nodepath := ${if $(_modules),NODE_PATH=${subst $(space),:,$(_modules)},}}
+    # the tool bin directories, colon-joined, prepended to {PATH} at launch (see {.run}) so the
+    # launch command resolves to the toolchain's executable
+    ${eval _toolbin := ${subst $(space),:,${strip ${foreach _t,$(_tools),$(toolchain.$(_t).bin)}}}}
+    ${eval _toolenv := ${strip ${foreach _t,$(_tools),$(toolchain.$(_t).env)}}}
+    ${eval _env := ${strip $(runner.$(_runner).env) $(_nodepath) $(_toolenv) $($(1).env)}}
     # the working directory: a {staged} runner runs from the staging area, everything else in place
     ${eval _workdir := ${if ${filter staged,$(_prepare)},$(_stageroot),$($(1).prefix)}}
 
@@ -159,15 +171,20 @@ $(1): $(1).post
 $(1).pre: $($(1).pre)
 
 # prepare the environment; for {staged}, mirror the suite into the staging area and link the
-# modules in as node_modules; for {compiled}, depend on the built binary
-$(1).prepare: $($(1).prerequisites) $(1).pre ${if ${filter compiled,$(_prepare)},$(_binary),}
+# modules in as node_modules; for {compiled}, depend on the built binary. before anything, verify
+# every toolchain the suite opted into is installed, so a missing tool fails here with an
+# actionable message rather than partway through the runner
+$(1).prepare: $($(1).prerequisites) $(1).pre ${foreach _t,$(_tools),$(_t).verify} ${if ${filter compiled,$(_prepare)},$(_binary),}
 	@${call log.action,prepare,$(1)}
 	${if ${filter staged,$(_prepare)},@$(mkdirp) $(_stageroot) && $(cp.fr) $($(1).prefix). $(_stageroot)${if $($(1).stage.modules), && $(ln) -sfn $($(1).stage.modules) $(_stageroot)node_modules,},@true}
 
-# invoke the runner once, from the prepared working directory; its exit code decides pass/fail
+# invoke the runner once, from the prepared working directory; its exit code decides pass/fail.
+# the tool bin directories are prepended to the inherited {PATH} ({$(PATH)} is the environment path
+# make imported at startup), so the launch resolves the toolchain executable while node, git, and
+# the server under test stay reachable
 $(1).run: $(1).prepare
 	@${call log.action,$(_runner),$(1)}
-	@$(cd) $(_workdir) ; $(_env) $(_launch)
+	@$(cd) $(_workdir) ; ${if $(_toolbin),PATH="$(_toolbin):$(PATH)" ,}$(_env) $(_launch)
 
 # teardown
 $(1).post: $(1).run $($(1).post)
@@ -188,6 +205,9 @@ $(1).info.runner:
 	@${call log.var,launch,$(_launch)}
 	@${call log.var,workdir,$(_workdir)}
 	@${call log.var,modules,$($(1).stage.modules)}
+	@${call log.var,toolchain,$(_tools)}
+	@${call log.var,path,$(_toolbin)}
+	@${call log.var,env,$(_env)}
 
 # just in case...
 .PHONY: $(1) $(1).pre $(1).prepare $(1).run $(1).post $(1).clean

--- a/make/toolchains/init.mm
+++ b/make/toolchains/init.mm
@@ -29,6 +29,17 @@ define toolchain.init =
     ${eval toolchain.$(1).home := $(toolchains.home)/$(1)}
     # the artifact whose presence proves the tool is installed and intact
     ${eval toolchain.$(1).sentinel ?= $(toolchain.$(1).home)/node_modules/.bin/$(1)}
+
+    # the consumer interface: what a project that declares it uses this tool needs in order to
+    # reach the installation. a {node} tool contributes its {node_modules} to {NODE_PATH} so the
+    # suite's own sources resolve their bare imports, and its {node_modules/.bin} to {PATH} so the
+    # runner can invoke the tool's executable; other kinds contribute nothing here and rely entirely
+    # on {env} below
+    ${eval toolchain.$(1).modules ?= ${if ${filter node,$(toolchain.$(1).kind)},$(toolchain.$(1).home)/node_modules,}}
+    ${eval toolchain.$(1).bin ?= ${if ${filter node,$(toolchain.$(1).kind)},$(toolchain.$(1).home)/node_modules/.bin,}}
+    # extra environment a consumer must set to use the tool, beyond {NODE_PATH} and {PATH}; tool
+    # specific, so each definition fills it in (e.g. a browser path); empty when nothing more is needed
+    ${eval toolchain.$(1).env ?=}
 # all done
 endef
 

--- a/make/toolchains/playwright/playwright.mm
+++ b/make/toolchains/playwright/playwright.mm
@@ -16,8 +16,13 @@ toolchain.playwright.browsers = $(toolchain.playwright.home)/browsers
 
 # the consumer environment: a project using playwright must point it at these browsers, since they
 # live inside the toolchain rather than the default per-user cache. {modules} is supplied generically
-# by {toolchain.init} for {node} tools, so it is not repeated here
-toolchain.playwright.env = PLAYWRIGHT_BROWSERS_PATH=$(toolchain.playwright.browsers)
+# by {toolchain.init} for {node} tools, so it is not repeated here. the {DEP0205} suppression is a
+# stopgap: playwright 1.60 installs its TS loader through node's now-deprecated {module.register()},
+# which recent node flags loudly on every worker; it is harmless and silenced narrowly (only this one
+# code) until a playwright release that adopts {module.registerHooks()} lets us drop it
+toolchain.playwright.env = \
+    PLAYWRIGHT_BROWSERS_PATH=$(toolchain.playwright.browsers) \
+    NODE_OPTIONS=--disable-warning=DEP0205
 
 
 # install the toolchain: stage the pinned manifest, fetch the framework, then the browsers

--- a/make/toolchains/playwright/playwright.mm
+++ b/make/toolchains/playwright/playwright.mm
@@ -14,6 +14,11 @@ toolchain.playwright.version := 1.60.0
 # self-contained, so {playwright.clean} removes everything and environments cannot drift
 toolchain.playwright.browsers = $(toolchain.playwright.home)/browsers
 
+# the consumer environment: a project using playwright must point it at these browsers, since they
+# live inside the toolchain rather than the default per-user cache. {modules} is supplied generically
+# by {toolchain.init} for {node} tools, so it is not repeated here
+toolchain.playwright.env = PLAYWRIGHT_BROWSERS_PATH=$(toolchain.playwright.browsers)
+
 
 # install the toolchain: stage the pinned manifest, fetch the framework, then the browsers
 playwright.install:


### PR DESCRIPTION
## Summary

Builds on the toolchains first cut (env-level developer tools installed once per
environment) by giving **test suites** a way to *use* a toolchain without owning it.
The motivating case is the qed `qed.ux.playwright` suite, whose framework
`node_modules` lived under the per-build-context `$(qed.tmpdir)` and vanished on every
`mm clean`. A suite can now simply declare the toolchains it needs and mm wires up the
rest.

## What changed

**Toolchain consumer interface** (`make/toolchains/init.mm`, `make/toolchains/playwright/playwright.mm`)
A toolchain now publishes what a consumer needs to reach it:
- `toolchain.<tool>.modules` — the `node_modules` to put on `NODE_PATH` (auto for `kind=node`, empty otherwise), so a suite's own sources resolve their bare imports.
- `toolchain.<tool>.bin` — the `node_modules/.bin` to put on `PATH`, so the runner can invoke the tool's executable.
- `toolchain.<tool>.env` — any extra environment the tool needs. playwright fills this with `PLAYWRIGHT_BROWSERS_PATH`, keeping its browsers inside the env-specific toolchain rather than a shared global cache.

**Opt-in suite trait** (`make/tests/init.mm`)
New `<suite>.toolchain` trait, **empty by default** (singular, list-valued, matching the
existing `<suite>.extern` convention). A suite that names no toolchain is completely
untouched — no opt-out anywhere.

**Runner consumption** (`make/tests/rules.mm`)
When a runner suite opts in, mm:
- adds each tool's `verify` as a `prepare` prerequisite, so a missing tool fails early with an actionable message (the error-first contract) instead of partway through the runner;
- composes a single `NODE_PATH` from the tools' `modules` (a list, so several tools coexist without collision);
- prepends the tools' `bin` directories to `PATH` (using `$(PATH)`, the environment path make imported at startup, so node/git/the server under test stay reachable);
- folds in each tool's `env`.

All of this is **scoped to the suite's launch** — it never leaks into other targets or
the user's shell.

**Launch the binary, not `npx`** (`make/runners/playwright.mm`)
With the toolchain's `node_modules/.bin` on `PATH`, the playwright runner launches
`playwright test` directly. A missing tool now fails loudly rather than `npx` silently
fetching a copy from the network.

## Consumer side

A suite goes from a per-build-context `node_modules` plus an `npm install` recipe to a
single line:

```make
<suite>.toolchain := playwright
```

## Notes

- The approach relies on `NODE_PATH`, which only feeds playwright's **CommonJS** config/spec
  loader. A suite that uses it must stay CJS (`.ts`, no `"type": "module"`); an ESM switch
  would need a different resolution scheme. This is called out in the consuming suite.
- The toolchain location is environment-keyed (`~/tools/mm/$ENV/toolchains`), so the wiring
  is consistent within an environment and shared across build contexts.

## DEP0205 stopgap

`toolchain.playwright.env` also sets `NODE_OPTIONS=--disable-warning=DEP0205`. This is a
temporary, narrowly-scoped suppression, **not** a behavior change:

- playwright 1.60.0 (the latest *stable*) installs its TypeScript loader through Node's
  now-deprecated `module.register()`; recent Node (v26) emits a `DEP0205` deprecation
  warning once per worker process, cluttering every run.
- It is harmless — the loader works and tests pass — and entirely upstream; nothing in mm
  or a consuming suite can change how playwright registers its loader.
- `--disable-warning=DEP0205` silences **only** that one code, leaving every other warning,
  error, and the test results intact, and is a no-op on Node versions that never emit it.
- There is no stable playwright to bump the pin to yet (only 1.61 alphas). Drop this line
  once a stable playwright release adopts `module.registerHooks()`.

## Status

Verified end-to-end against qed's `qed.ux.playwright` suite: `verify` passes when the tool
is present and errors when absent; `NODE_PATH`/`PATH`/browser path resolve from the
env-keyed toolchain; the staged runner resolves `@playwright/test`, launches chromium from
the toolchain's own browsers, runs the specs (35 passing), and the DEP0205 noise is gone.