### PR TITLE
make/extern: follow package .dependencies to compute a project's external dependencies

### DIFF
--- a/make/extern/hdf5/init.mm
+++ b/make/extern/hdf5/init.mm
@@ -33,8 +33,10 @@ hdf5.rpath = $(hdf5.libpath)
 # the names of the libraries
 hdf5.libraries := hdf5_cpp hdf5
 
-# my dependencies
-hdf5.dependencies =
+# my dependencies; a parallel build links against {mpi}, so a {parallel} value naming it induces a
+# load-time edge that pulls {mpi} into any asset that depends on {hdf5}. evaluated lazily so it sees
+# the effective {hdf5.parallel}, whether defaulted here, set by the user, or detected by the pkgdb
+hdf5.dependencies = ${if ${findstring mpi,$(hdf5.parallel)},mpi}
 
 
 # end of file

--- a/make/extern/init.mm
+++ b/make/extern/init.mm
@@ -60,6 +60,13 @@ define extern.if.available =
 endef
 
 
+# a token's {.dependencies}, or empty when the variable was never defined; the {flavor} probe lets
+# the closure walk a heterogeneous {.extern} (internal libraries, externals that never set the field)
+# without tripping -warn-undefined, since {flavor} reports on a name without referencing it
+#   usage: extern.deps.of {token}
+extern.deps.of = ${if ${filter-out undefined,${flavor $(1).dependencies}},$($(1).dependencies)}
+
+
 # the depth-first visitor behind {extern.closure}; a 3-color walk that marks a node {gray} while it
 # is on the current stack and {black} once finished, so a {gray} hit is a genuine cycle (warn) while
 # a {black} hit is a shared dependency (skip). prepending each node as it finishes yields the post
@@ -67,7 +74,7 @@ endef
 # kept on a single logical line on purpose — newlines inside a {define} leak into the expansion
 #   usage: extern.closure.visit {package}
 define extern.closure.visit =
-${if ${filter $(1),$(extern.closure.black)},,${if ${filter $(1),$(extern.closure.gray)},${warning extern: dependency cycle detected at '$(1)'},${eval extern.closure.gray += $(1)}${foreach dep,$($(1).dependencies),${call extern.closure.visit,$(dep)}}${eval extern.closure.black += $(1)}${eval extern.closure.order := $(1) $(extern.closure.order)}}}
+${if ${filter $(1),$(extern.closure.black)},,${if ${filter $(1),$(extern.closure.gray)},${warning extern: dependency cycle detected at '$(1)'},${eval extern.closure.gray += $(1)}${foreach dep,${call extern.deps.of,$(1)},${call extern.closure.visit,$(dep)}}${eval extern.closure.black += $(1)}${eval extern.closure.order := $(1) $(extern.closure.order)}}}
 endef
 
 
@@ -76,6 +83,54 @@ endef
 # through {eval}, so it must not be called while it is already expanding (it is not re-entrant)
 #   usage: extern.closure {roots}
 extern.closure = ${strip ${eval extern.closure.gray :=}${eval extern.closure.black :=}${eval extern.closure.order :=}${foreach root,$(1),${call extern.closure.visit,$(root)}}$(extern.closure.order)}
+
+
+# resolve an asset's external dependencies now that the whole graph is loaded: {requested} is the
+# transitive {.dependencies} closure of the declared {.extern}, while {supported} and {available}
+# narrow it to what mm can configure and what is actually installed, all in link order. this runs
+# post-load because a load-time edge (a parallel {hdf5} electing {mpi}) is invisible at the earlier,
+# pre-load pass that seeds the loader. the final step folds the asset's internal dependencies and its
+# installed external closure back into {.extern} — computed once here — so the build recipes pick
+# them up unchanged; the induced-but-uninstalled complaint runs first, while {.extern} still holds
+# the original declaration that tells an induced package apart from a directly requested one
+#   usage: extern.resolve {asset}
+define extern.resolve =
+    ${eval $(1).extern.requested := ${call extern.closure,$($(1).extern)}}
+    ${eval $(1).extern.supported := ${call extern.is.supported,$($(1).extern.requested)}}
+    ${eval $(1).extern.available := ${call extern.is.available,$($(1).extern.supported)}}
+    ${eval _induced := ${call extern.unsatisfied.induced,$(1)}}
+    ${if $(_induced),
+        ${call extern.complain,extern $(1): induced dependency '$(_induced)' is not installed (no <pkg>.dir); the link will likely fail}
+    }
+    ${eval $(1).extern := ${filter-out $(extern.supported),$($(1).extern)} $($(1).extern.available)}
+endef
+
+
+# the externals an asset needs that mm can configure but cannot find installed (no {<pkg>.dir}),
+# restricted to the ones induced by the dependency closure rather than declared directly. these are
+# the surprising failures the user cannot see in their own config, so they are worth a build-time
+# complaint; directly-declared shortfalls are left for {extern.verify} to audit
+#   usage: extern.unsatisfied.induced {asset}
+extern.unsatisfied.induced = \
+    ${filter-out $($(1).extern) $($(1).extern.available),$($(1).extern.supported)}
+
+
+# a package's own direct {.dependencies} that are not installed; used by the verify report to flag,
+# for instance, a parallel {hdf5} whose {mpi} has no install to link against
+#   usage: extern.deps.missing {package}
+extern.deps.missing = ${filter-out $(extern.available),$($(1).dependencies)}
+
+
+# the severity of a build-configuration complaint. {warning} lets the build proceed so the user can
+# reach a real authority — the compiler or the linker — before stopping; flip to {error} to fail
+# early instead. {extern.verify} audits the configuration on its own and is never gated by this
+extern.complain.severity ?= warning
+
+# emit a build-configuration complaint at the configured severity. the severity must select a
+# literal {warning}/{error} function name: make resolves the function at parse time, so an indirect
+# {${$(severity) ...}} would be read as a reference to an undefined variable instead
+#   usage: extern.complain {message}
+extern.complain = ${if ${filter error,$(extern.complain.severity)},${error $(1)},${warning $(1)}}
 
 
 # construct the contribution of an external package to the compile line

--- a/make/extern/init.mm
+++ b/make/extern/init.mm
@@ -60,6 +60,24 @@ define extern.if.available =
 endef
 
 
+# the depth-first visitor behind {extern.closure}; a 3-color walk that marks a node {gray} while it
+# is on the current stack and {black} once finished, so a {gray} hit is a genuine cycle (warn) while
+# a {black} hit is a shared dependency (skip). prepending each node as it finishes yields the post
+# order already reversed, i.e. link order: a dependent always precedes the packages it pulls in.
+# kept on a single logical line on purpose — newlines inside a {define} leak into the expansion
+#   usage: extern.closure.visit {package}
+define extern.closure.visit =
+${if ${filter $(1),$(extern.closure.black)},,${if ${filter $(1),$(extern.closure.gray)},${warning extern: dependency cycle detected at '$(1)'},${eval extern.closure.gray += $(1)}${foreach dep,$($(1).dependencies),${call extern.closure.visit,$(dep)}}${eval extern.closure.black += $(1)}${eval extern.closure.order := $(1) $(extern.closure.order)}}}
+endef
+
+
+# the transitive {.dependencies} closure of a set of root packages, in link order (each dependent
+# ahead of the packages it requires); the result is a superset of {roots}. relies on globals mutated
+# through {eval}, so it must not be called while it is already expanding (it is not re-entrant)
+#   usage: extern.closure {roots}
+extern.closure = ${strip ${eval extern.closure.gray :=}${eval extern.closure.black :=}${eval extern.closure.order :=}${foreach root,$(1),${call extern.closure.visit,$(root)}}$(extern.closure.order)}
+
+
 # construct the contribution of an external package to the compile line
 #   usage: extern.compile.options.this {language} {package}
 extern.compile.options.this = \

--- a/make/extern/model.mm
+++ b/make/extern/model.mm
@@ -59,6 +59,7 @@ define extern.load.one =
         }
         ${eval $(1).markers.required ?=}
         ${eval $(1).markers.required.hint ?=}
+        ${eval $(1).dependencies ?=}
         ${foreach dep, $($(1).dependencies),
             ${call extern.load.one,$(dep)}
         }

--- a/make/extern/model.mm
+++ b/make/extern/model.mm
@@ -44,20 +44,37 @@ extern.available := \
         ${if ${call extern.exists,$(package)},$(package),} \
     }
 
-# load the configuration files for a set of dependencies; {markers.required} and its hint are
-# opt-in, so they get defaulted to empty for every package — otherwise the marker checks reference
-# an undefined variable and trip -warn-undefined. the defaults live in the body below; they cannot
-# be written as comments inside the {define} because comment text would leak into the expansion
+# include one package's configuration exactly once, then descend into its {.dependencies}. the
+# recursion follows {.dependencies} only after the package's own {init.mm} has been read, so an edge
+# computed at load time (e.g. a parallel {hdf5} electing {mpi}) is already defined when we reach it.
+# {markers.required} and its hint are opt-in, so they are defaulted to empty here — otherwise the
+# marker checks reference an undefined variable and trip -warn-undefined. these defaults cannot be
+# written as comments inside the {define} because comment text would leak into the expansion
+#   usage: extern.load.one {package}
+define extern.load.one =
+    ${if ${filter $(1),$(extern.loaded)},,
+        ${eval extern.loaded += $(1)}
+        ${foreach loc, ${extern.all},
+            ${eval include ${realpath $(loc)/$(1)/init.mm $(loc)/$(1)/rules.mm}}
+        }
+        ${eval $(1).markers.required ?=}
+        ${eval $(1).markers.required.hint ?=}
+        ${foreach dep, $($(1).dependencies),
+            ${call extern.load.one,$(dep)}
+        }
+    }
+endef
+
+
+# load the configuration files for a set of dependencies and their transitive {.dependencies},
+# returning the full set of packages actually loaded
 #   usage extern.load {dependencies}
 define extern.load =
+    ${eval extern.loaded :=}
     ${foreach dep, $(1),
-        ${foreach loc, ${extern.all},
-            ${eval include ${realpath $(loc)/$(dep)/init.mm $(loc)/$(dep)/rules.mm}}
-        }
-        ${eval $(dep).markers.required ?=}
-        ${eval $(dep).markers.required.hint ?=}
-	$(dep)
+        ${call extern.load.one,$(dep)}
     }
+    $(extern.loaded)
 endef
 
 

--- a/make/extern/rules.mm
+++ b/make/extern/rules.mm
@@ -30,6 +30,8 @@ define extern.verify.report =
 	@${call log.var,"libraries","$($(1).libraries)"}
 	@${if ${call extern.markers.libraries.missing,$(1)},${call log.error,"unresolved libraries: ${call extern.markers.libraries.missing,$(1)}"},${call log.info,"libraries ok"}}
 	@${if ${call extern.markers.required.missing,$(1)},${call log.error,"unset required values: ${call extern.markers.required.missing,$(1)}"},:}
+	@${if $($(1).dependencies),${call log.var,"dependencies","$($(1).dependencies)"},:}
+	@${if ${call extern.deps.missing,$(1)},${call log.error,"unavailable dependencies: ${call extern.deps.missing,$(1)}"},${if $($(1).dependencies),${call log.info,"dependencies ok"},:}}
 endef
 
 

--- a/make/projects/model.mm
+++ b/make/projects/model.mm
@@ -48,6 +48,20 @@ define project.boot.workflows =
 endef
 
 
+# resolve the external dependencies of every asset now that the whole graph is loaded; a {define}
+# because this multi-line body would be read line-by-line — and break — at the top level of the
+# makefile
+#   usage: projects.extern.resolve {projects}
+define projects.extern.resolve =
+    ${foreach project, $(1),
+        ${foreach asset, $($(project).contents),
+            ${call extern.resolve,$(asset)}
+        }
+    }
+# all done
+endef
+
+
 # bootstrap
 # ${info --   project constructors}
 ${foreach project,$(projects), ${eval ${call project.boot,$(project)}}}
@@ -70,6 +84,10 @@ projects.extern.loaded := ${sort \
 # warn loudly about any loaded external that could not set a critical value, before the build
 # reaches a link that would fail with a far less obvious message
 ${call extern.markers.required.warn, $(projects.extern.loaded)}
+
+# now that the whole external graph is loaded, resolve each asset's dependency tiers and complain
+# about anything induced-but-uninstalled (see {projects.extern.resolve})
+${eval ${call projects.extern.resolve, $(projects)}}
 
 # ${info --   project workflows}
 ${foreach project,$(projects), ${eval ${call project.boot.workflows,$(project)}}}


### PR DESCRIPTION
## Summary

Makes package `.dependencies` load-bearing. An asset's external-dependency list is now the **transitive closure** of its declared externs — following each package's `.dependencies` — narrowed to what is actually installed. A package can therefore express an *induced* dependency (e.g. a parallel `hdf5` requiring `mpi`) and have it reach every consumer's compile and link lines automatically, replacing the old pattern where projects hand-coded `${if ${findstring mpi,$(hdf5.parallel)},mpi}` in their own config.

## The problem

Projects used to reach into a package's internals at read time, e.g. in `pyre.mm`:

```make
pyre.lib.extern := ... hdf5 ${if ${findstring mpi,$(hdf5.parallel)},mpi}
```

But `hdf5.parallel` is set by `hdf5/init.mm`, which is loaded by `extern.load` **after** all project configs are read and assets booted. So `$(hdf5.parallel)` was undefined when the conditional ran:

- the clause was effectively dead (it only worked via a make command-line override), and
- under `-warn-undefined` it emitted `undefined variable 'hdf5.parallel'`.

Root cause: the property driving the dependency decision is **owned by the package and known only at load time**, yet the decision was being made by the consumer **before the package loaded**. Meanwhile `.dependencies` was purely documentary — declared by every package but never walked.

## What changed

### Foundation (`70fb839`)

- **`extern.closure {roots}`** — a 3-color DFS over `.dependencies` returning the transitive closure in **link order** (each dependent ahead of what it requires). A `gray` hit is a real cycle (warn); a `black` hit is a shared dependency (dedup). Prepend-on-finish yields link order directly, no separate reverse pass.
- **`extern.deps.of`** — reads `.dependencies` via a `${flavor}` probe so the walk tolerates tokens that never set the field (internal libraries, externs without deps) without tripping `-warn-undefined`.
- **`extern.load` is now a DFS** (`extern.load.one`): it includes a package's config, then follows its `.dependencies` — so a load-time edge (parallel `hdf5` electing `mpi`) is already defined by the time we recurse into it. Defaults `.dependencies`, `.markers.required`, and the hint to empty per loaded package.
- **`hdf5.dependencies = ${if ${findstring mpi,$(hdf5.parallel)},mpi}`** — the induced edge now lives in the package that owns the knowledge, evaluated lazily so it sees the effective `hdf5.parallel`.

### Resolution (`d598e6e`)

- **`extern.resolve {asset}`** runs post-load for every asset and recomputes the tiers:
  - `.extern.requested` = closure of the declared `.extern`
  - `.extern.supported` = requested ∩ mm-configurable
  - `.extern.available` = supported ∩ **installed** (`<pkg>.dir` resolves), in link order
  - then **folds internal deps + the installed external closure back into `.extern`** (computed once) so the build recipes consume it unchanged — no recipe edits anywhere, and `tests/rules.mm` benefits for free.
- **Availability gate** (`<pkg>.dir`): a package in the closure but with no install is dropped from `.available`. The *induced-but-uninstalled* case — e.g. a parallel `hdf5` with no `mpi` installed — raises a self-describing complaint, distinguished from directly-declared shortfalls (left to `extern.verify`).
- **Severity knob** — `extern.complain` routes complaints through `extern.complain.severity` (default `warning`) using literal `warning`/`error` function names. Warn-and-continue today so a real authority (the compiler/linker) faces the impossible config; flip to `error` to fail early. `extern.verify` audits independently and is never gated by this.
- The per-package **verify report** gains a `dependencies` line and an unavailable-dependencies check.

## make gotchas fixed along the way (recorded for future work)

- Comments inside a `define` body are **literal**, not stripped — `# all done` leaked into the expansion. Fixed by moving comments out and invoking defines via `${eval ${call …}}`.
- A multi-line `${foreach}` at the **top level** of a makefile is read line-by-line and breaks (`unterminated foreach`); it must live inside a `define`, invoked on one line.
- The indirect-function trick `${$(severity) …}` does **not** work — make resolves the function name at parse time, so it degraded to an undefined-variable reference. Replaced with `${if ${filter error,…},${error …},${warning …}}`.
- A bare `${call somedef,…}` at top level leaks the define's trailing comment and body whitespace into the parse stream → `missing separator`. Invoke via `${eval ${call …}}`.

## Consumer changes (separate repos, by the author)

`pyre.mm`, `qed`, and `qef` dropped their hand-coded `${if ${findstring mpi,$(hdf5.parallel)},mpi}` clauses; the closure now supplies `mpi`.

## Verification

Against real `pyre` via `~/dv/mm/mm`:

| `hdf5.parallel` | `pyre.lib.extern` | `h5.ext.extern` |
|---|---|---|
| `off` | `journal.lib hdf5` | `journal.lib python pybind11 hdf5` |
| `mpi` | `journal.lib hdf5 mpi` | `journal.lib python pybind11 hdf5 mpi` |

`journal.lib` (internal) is preserved; `mpi` is pulled in transitively only when hdf5 is parallel; `extern.verify` exits 0; no undefined-variable warnings originate from mm.

## Notes / follow-ups

- Topological order matters only for **static archives**; for shared libraries (the common case) link order is immaterial. The closure is a valid topo order regardless, though independent packages may be reordered.
- `hdf5.parallel` still defaults to `off` and is user/config-set. Detecting it from the conda pkgdb (the `mpi_*` build variant) is a natural follow-up, so even a *detected* parallel build would induce `mpi`.
