### PR TITLE
Added support for flang

### DIFF
--- a/examples/hello/.mm/hello.mm
+++ b/examples/hello/.mm/hello.mm
@@ -16,6 +16,8 @@ hello.libraries := hello.lib
 hello.extensions := hello.ext
 # and a test suite
 hello.tests := hello.tests.hello.pkg hello.tests.hello.lib
+# a docker image for building and testing on linux64 (clang/flang on a recent ubuntu)
+hello.docker-images := hello.questing-clang
 
 # the package meta-data
 hello.pkg.stem := hello
@@ -64,6 +66,9 @@ say.hello.ally.argv := hello ally
 say.hello.mac.argv := hello mac
 # say goodbye to matthias
 say.goodbye.matthias.argv := goodbye mat
+
+# pull in the docker image configuration
+include $(hello.docker-images)
 
 # show me
 # ${info -- done with hello }

--- a/examples/hello/.mm/hello.mm
+++ b/examples/hello/.mm/hello.mm
@@ -25,7 +25,8 @@ hello.pkg.drivers := say
 
 # the library meta-data
 hello.lib.stem := hello
-hello.lib.extern := pyre
+# {fortran} pulls in the flang runtime so the c++-driven link resolves {mat.f03}'s symbols
+hello.lib.extern := pyre fortran
 hello.lib.c++.flags += $($(compiler.c++).std.c++17)
 
 # the extension meta-data

--- a/examples/hello/.mm/hello.questing-clang
+++ b/examples/hello/.mm/hello.questing-clang
@@ -9,8 +9,9 @@ hello.questing-clang.name := questing-clang
 hello.questing-clang.root := etc/docker/
 
 # {hello} lives inside the {mm} repository, so mounting that one repo brings along both the
-# build tool and this example; its parent is three levels up from {examples/hello}
-hello.questing-clang.mounts.source := ${realpath $(hello.home)/../../..}/
+# build tool and this example; its parent is three levels up from {examples/hello}. defer
+# expansion with {=} so {hello.home} is read when the mount is assembled, not at include time
+hello.questing-clang.mounts.source = ${realpath $(hello.home)/../../..}/
 # mount the {mm} repository at /usr/local/src/mm
 hello.questing-clang.launch.mounts := mm
 

--- a/examples/hello/.mm/hello.questing-clang
+++ b/examples/hello/.mm/hello.questing-clang
@@ -1,0 +1,18 @@
+# -*- makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# questing-clang image configuration
+hello.questing-clang.name := questing-clang
+hello.questing-clang.root := etc/docker/
+
+# {hello} lives inside the {mm} repository, so mounting that one repo brings along both the
+# build tool and this example; its parent is three levels up from {examples/hello}
+hello.questing-clang.mounts.source := ${realpath $(hello.home)/../../..}/
+# mount the {mm} repository at /usr/local/src/mm
+hello.questing-clang.launch.mounts := mm
+
+
+# end of file

--- a/examples/hello/etc/docker/questing-clang/Dockerfile
+++ b/examples/hello/etc/docker/questing-clang/Dockerfile
@@ -1,0 +1,103 @@
+## -*- docker-image-name: "hello:questing-clang" -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+# based on ubuntu
+FROM ubuntu:questing
+
+# set up some build variables
+ARG instance=questing-clang
+# python version
+ARG python_version=3.14
+ARG python=python${python_version}
+# locations
+ARG prefix=/usr/local
+ARG srcdir=${prefix}/src
+# the build system; {mm} is the executable driver, not the legacy {mm.py}
+ARG mm="${python} ${srcdir}/mm/mm"
+
+# environment
+# colorize (for fun)
+ENV TERM=xterm-256color
+# set up the dynamic linker path
+ENV LD_LIBRARY_PATH=${prefix}/lib
+# export the python choice
+ENV PYTHON=${python}
+# and the path to {mm}
+ENV MM=${mm}
+
+
+# update the package repository
+RUN apt update -y
+# get the latest
+RUN apt dist-upgrade -y
+
+# install the base software stack
+RUN DEBIAN_FRONTEND=noninteractive \
+        apt install -y \
+        curl
+
+# install micromamba and set up the environment
+WORKDIR /root/.local
+# make the bin directory
+RUN mkdir -p bin
+# fetch the latest
+RUN curl "https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-linux-$(uname -m)" -o bin/micromamba -fsSL --compressed
+# make it executable
+RUN chmod +x bin/micromamba
+# copy the environment configuration file
+COPY etc/docker/${instance}/hello-env.yaml hello.yaml
+# create the hello environment
+RUN /root/.local/bin/micromamba env create --quiet --yes --file hello.yaml --prefix=/root/.local/envs/hello
+
+# setup the interactive environment
+# go home
+WORKDIR /root
+# copy the files with support for interactive use
+COPY etc/docker/${instance}/inputrc .inputrc
+# the startup file
+COPY etc/docker/${instance}/bashrc bashrc.in
+# expand
+RUN sed \
+        -e "s:@SRCDIR@:${srcdir}:g" \
+        bashrc.in > .bashrc
+# clean up
+RUN rm bashrc.in
+
+# copy the prompt
+COPY etc/docker/${instance}/prompt.py prompt.py.in
+# expand
+RUN sed \
+        -e "s:@INSTANCE@:${instance}:g" \
+        prompt.py.in > prompt.py
+# clean up
+RUN rm prompt.py.in
+
+# make the pyre configuration directory
+WORKDIR /root/.pyre
+# get the {mm} configuration file
+COPY etc/docker/${instance}/mm.yaml mm.yaml.in
+# expand
+RUN sed \
+        -e "s:@PYTHON_VERSION@:${python_version}:g" \
+        mm.yaml.in > mm.yaml
+# clean up
+RUN rm mm.yaml.in
+
+# place the {mm} control file
+WORKDIR /root/.mm
+# copy the relevant configuration file
+COPY etc/docker/${instance}/config.mm config.mm.in
+# expand
+RUN sed \
+        -e "s:@PYTHON_VERSION@:${python_version}:g" \
+        config.mm.in > config.mm
+# clean up
+RUN rm config.mm.in
+
+# go to the source directory
+WORKDIR /usr/local/src
+
+
+# end of file

--- a/examples/hello/etc/docker/questing-clang/bashrc
+++ b/examples/hello/etc/docker/questing-clang/bashrc
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+# the system profile
+if [ -r /etc/profile ]; then
+    source /etc/profile
+fi
+
+# umask
+umask u+rwx,g+rwx,o+rx
+# the language/encoding
+export LANG=en_US.UTF-8
+
+# initialize micromamba
+export MAMBA_EXE=${HOME}/.local/bin/micromamba
+export MAMBA_ROOT_PREFIX=${HOME}/.local
+# enable the shell integration
+eval "$(${MAMBA_EXE} shell hook --shell bash ${MAMBA_ROOT_PREFIX})"
+# activate the desired environment
+micromamba activate hello
+
+# prompt
+export PROMPT_COMMAND=prompter
+
+prompter() {
+  history -a
+  export PS1="$(python3 ${HOME}/prompt.py)"
+}
+
+# aliases
+alias d='ls -ahGF'
+alias dl='ls -ahGFl'
+# git
+alias git.hash='git log --format=format:"%h" -n 1'
+alias git.branch='git rev-parse --abbrev-ref HEAD'
+alias git.status='git status --porcelain --branch --ignored'
+alias git.tag='git describe --tags --long --always'
+
+# the location of the sources
+export SRCDIR=@SRCDIR@
+# mm 5.x
+alias mm='python3 ${SRCDIR}/mm/mm'
+
+# end of file

--- a/examples/hello/etc/docker/questing-clang/config.mm
+++ b/examples/hello/etc/docker/questing-clang/config.mm
@@ -1,0 +1,11 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# nothing to configure here: with {pkgdb: conda} every external dependency
+# is resolved from the active conda environment
+
+
+# end of file

--- a/examples/hello/etc/docker/questing-clang/hello-env.yaml
+++ b/examples/hello/etc/docker/questing-clang/hello-env.yaml
@@ -1,0 +1,27 @@
+# -*- yaml -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+name: hello
+
+channels:
+  - conda-forge
+
+dependencies:
+  # tools for building from source
+  - binutils
+  - git
+  - make
+  - vim
+  # the clang/flang toolchain: clang and clang++ for C/C++, flang for Fortran
+  - clang
+  - clangxx
+  - flang
+  # python and runtime packages
+  - python
+  - pybind11
+  # the framework {hello} depends on
+  - pyre
+
+# end of file

--- a/examples/hello/etc/docker/questing-clang/hello-env.yaml
+++ b/examples/hello/etc/docker/questing-clang/hello-env.yaml
@@ -18,6 +18,7 @@ dependencies:
   - clang
   - clangxx
   - flang
+  - libflang-rt
   # python and runtime packages
   - python
   - pybind11

--- a/examples/hello/etc/docker/questing-clang/inputrc
+++ b/examples/hello/etc/docker/questing-clang/inputrc
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+  set editing-mode vi
+
+# end of file

--- a/examples/hello/etc/docker/questing-clang/mm.yaml
+++ b/examples/hello/etc/docker/questing-clang/mm.yaml
@@ -1,0 +1,24 @@
+# -*- yaml -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+# mm configuration
+mm:
+
+  # let conda place the build products; no need for {prefix}, {bldroot}, or {pycPrefix}
+  mode: conda
+  # resolve external dependencies straight from the active conda environment
+  pkgdb: conda
+  # targets
+  target: opt,shared
+  # compilers; the {clang} family supplies clang/clang++ for C/C++ and flang for Fortran
+  compilers: clang, python/python3
+
+  # misc
+  # the name of GNU make
+  make: make
+  # local makefiles
+  local: Make.mmm
+
+# end of file

--- a/examples/hello/etc/docker/questing-clang/prompt.py
+++ b/examples/hello/etc/docker/questing-clang/prompt.py
@@ -1,0 +1,671 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2024 all rights reserved
+
+
+# externals
+import os
+import re
+import subprocess
+import sys
+
+
+# shell detection
+isBASH = True if sys.argv[-1] == "bash" else False
+isZSH = True if sys.argv[-1] == "zsh" else False
+
+
+# assemble the prompt
+def prompt():
+    """
+    Assemble and print the prompt
+    """
+    # assemble
+    prompt = "".join(generate())
+    # and print
+    print(prompt, end="")
+    # all done
+    return
+
+
+# the prompt generator
+def generate():
+    """
+    Make a prompt string for the bash shell
+    """
+    # compute a pretty cwd
+    cwd = getcwd()
+    # decorate the title of the window
+    yield from decorateWindow(cwd=cwd)
+
+    # look for an active python virtual environment
+    venv = os.environ.get("VIRTUAL_ENV")
+    # if there s one
+    if venv:
+        # extract the name of the environment
+        name = venv.split("/")[-1]
+        # show its name
+        yield from pythonEnvironment(name)
+
+    # look for an active conda environment
+    conda = os.environ.get("CONDA_DEFAULT_ENV")
+    # if there s one
+    if conda:
+        # show its name
+        yield from condaEnvironment(conda)
+
+    # if bzr is installed
+    try:
+        # and we are within a bzr repository, show its status
+        yield from bzrRepository()
+    # otherwise
+    except:
+        # ignore
+        pass
+
+    # if git is installed
+    try:
+        # and we are within a git repository, show its status
+        yield from gitRepository()
+    # otherwise
+    except:
+        # ignore
+        pass
+
+    # add a final separator
+    yield from finalize(cwd=cwd)
+
+    # all done
+    return
+
+
+# support for python virtual environments
+def pythonEnvironment(name):
+    """
+    Show the name of the active python virtual environment
+    """
+    # decorate
+    yield f"{prompt_normal}("
+    # repository info
+    yield f"{venv_python}{name}"
+    # reset
+    yield f"{prompt_normal})"
+
+
+# support for conda environments
+def condaEnvironment(name):
+    """
+    Show the name of the active conda environment
+    """
+    # decorate
+    yield f"{prompt_normal}("
+    # repository info
+    yield f"{venv_conda}{name}"
+    # reset
+    yield f"{prompt_normal})"
+
+
+# support for bzr
+def bzrRepository():
+    """
+    Show the status of {bzr} repositories
+    """
+    # find out the revision number, which lets us detect whether this is a {bzr} worktree
+    cmd = ["bzr", "revno"]
+    # settings
+    options = {
+        "executable": "bzr",
+        "args": cmd,
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "universal_newlines": True,
+        "shell": False,
+    }
+    # invoke
+    with subprocess.Popen(**options) as bzr:
+        # collect the output
+        stdout, stderr = bzr.communicate()
+        # if there was an error
+        if bzr.returncode != 0:
+            # this is not a bzr repository, so we are done
+            return
+        # otherwise, extract the revno
+        revno = stdout.strip()
+        # decorate
+        yield f"{prompt_normal}["
+        # colorize
+        yield from bzrStatus()
+        # repository info
+        yield revno
+        # reset
+        yield f"{prompt_normal}]:"
+
+    # all done
+    return
+
+
+def bzrStatus():
+    """
+    Colorize based on the state of a bzr repository
+    """
+    # get status information
+    cmd = ["bzr", "status", "--short", "--no-classify"]
+    # settings
+    options = {
+        "executable": "bzr",
+        "args": cmd,
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "universal_newlines": True,
+        "shell": False,
+    }
+    # invoke
+    with subprocess.Popen(**options) as bzr:
+        # collect the output
+        stdout, stderr = bzr.communicate()
+        # if there was an error
+        if bzr.returncode != 0:
+            # bail
+            return
+        # otherwise, grab the report
+        report = bzrParseStatus(status=stdout.splitlines())
+        # if there are changed files
+        if report["changed"] > 0:
+            # colorize
+            yield branch_modified_worktree
+        elif report["new"] > 0:
+            # colorize
+            yield branch_modified_index
+        # otherwise
+        else:
+            # colorize
+            yield branch_clean
+
+    # all done
+    return
+
+
+def bzrParseStatus(status):
+    """
+    Parse the bzr status output and collect the statistics we need to colorize the prompt
+    """
+    # the summary table
+    table = {
+        "new": 0,
+        "changed": 0,
+        "ignored": 0,
+        "unknown": 0,
+    }
+    # go through the report
+    for line in status:
+        # attempt to match it
+        match = bzrParser.match(line)
+        # if we couldn't
+        if match is None:
+            # ignore and move on
+            continue
+        # get the enclosing group name
+        case = match.lastgroup
+
+        # new files
+        if case in bzrAdded:
+            # updated the counter
+            table["new"] += 1
+        # changed files
+        elif case in bzrChanged:
+            # update the counter
+            table["changed"] += 1
+        elif case in bzrIgnored:
+            # update the counter
+            table["ignore"] += 1
+        elif case in bzrUnknown:
+            # update the counter
+            table["unknown"] += 1
+
+    # all done
+    return table
+
+
+bzrCodes = "|".join(
+    [
+        r"(?P<added>\+N\s)",
+        r"(?P<removed>\-D\s)",
+        r"(?P<renamed>R \s)",
+        r"(?P<modified> M\s)",
+        r"(?P<kind> K\s)",
+        r"(?P<unknown>\?\s)",
+    ]
+)
+
+bzrParser = re.compile(rf"{bzrCodes}.+$")
+
+bzrAdded = {"added"}
+bzrChanged = {"removed", "renamed", "modified", "kind"}
+bzrIgnored = {"ignored"}
+bzrUnknown = {"unknown"}
+
+
+# support for git
+def gitRepository():
+    """
+    Show the status of {git} repositories
+    """
+    # set up the command
+    cmd = ["git", "status", "--porcelain", "--branch"]
+    # settings
+    options = {
+        "executable": "git",
+        "args": cmd,
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "universal_newlines": True,
+        "shell": False,
+    }
+    # invoke
+    with subprocess.Popen(**options) as git:
+        # collect the output
+        stdout, stderr = git.communicate()
+        # if there was an error
+        if git.returncode != 0:
+            # this is not a git repository, so we are done
+            return
+        # otherwise, parse the output
+        summary = gitParseStatus(status=stdout.splitlines())
+        # get the branch name
+        branch = summary["local"]
+        # get the divergence information
+        ahead = summary["ahead"]
+        behind = summary["behind"]
+        # get change info
+        index = summary["index"]
+        worktree = summary["worktree"]
+        conflicts = summary["conflicts"]
+
+        # start rendering
+        yield f"{prompt_normal}["
+
+        # if there are conflicts
+        if conflicts:
+            # mark it
+            status = branch_conflicts
+        # if both the index and the worktree have changes
+        elif worktree > 0 and index > 0:
+            # mark it
+            status = branch_modified
+        # if there are changes in the worktree
+        elif worktree > 0:
+            # mark it
+            status = branch_modified_worktree
+        # if there are changes in the index
+        elif index > 0:
+            # mark it
+            status = branch_modified_index
+        # otherwise
+        else:
+            # mark it as clean
+            status = branch_clean
+
+        # render the branch name in a color appropriate for its status
+        yield f"{status}{branch}"
+
+        # divergence information
+        if ahead or behind:
+            # add a separator
+            yield f"{prompt_normal}:"
+        # if we are ahead of the remote branch
+        if ahead:
+            # render
+            yield f"{branch_ahead}+{ahead}"
+        # if we are behind
+        if behind:
+            # render
+            yield f"{branch_behind}-{behind}"
+
+        # wrap up
+        yield f"{prompt_normal}]:"
+
+    # all done
+    return
+
+
+def gitParseStatus(status):
+    # the summary table
+    table = {
+        "local": None,
+        "remote": None,
+        "ahead": 0,
+        "behind": 0,
+        "worktree": 0,
+        "index": 0,
+        "conflicts": 0,
+    }
+    # go through the lines in {status}
+    for line in status:
+        # attempt to match it
+        match = gitParser.match(line)
+        # if we couldn't
+        if match is None:
+            # ignore and move on
+            continue
+        # get the enclosing group name
+        case = match.lastgroup
+        # look up the handler and dispatch
+        gitDispatcher[case](table=table, match=match)
+    # all done
+    return table
+
+
+def gitNoCommits(table, match):
+    """
+    Extract the branch name of a newly created repository
+    """
+    # set the branch name
+    table["local"] = match.group("new")
+    # all done
+    return table
+
+
+def gitDetached(table, match):
+    """
+    In detached HEAD state
+    """
+    # let's find out the hash of the current commit
+    cmd = ["git", "log", "--format=format:%h", "-n", "1"]
+    # settings
+    options = {
+        "executable": "git",
+        "args": cmd,
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "universal_newlines": True,
+        "shell": False,
+    }
+    # invoke
+    with subprocess.Popen(**options) as git:
+        # collect the output
+        stdout, stderr = git.communicate()
+        # get the hash
+        commit = stdout.strip()
+        # use it as a marker
+        table["local"] = commit
+
+    # all done
+    return table
+
+
+def gitTracking(table, match):
+    """
+    Extract the branch name from a repository that tracks a remote one
+    """
+    # get the match group dictionary
+    info = match.groupdict()
+    # set the branch name
+    table["local"] = info["local"]
+    table["remote"] = info["remote"]
+    table["ahead"] = 0 if info["ahead"] is None else int(info["ahead"])
+    table["behind"] = 0 if info["behind"] is None else int(info["behind"])
+    # all done
+    return table
+
+
+def gitLocal(table, match):
+    """
+    Extract the branch name from a repository that tracks a remote one
+    """
+    # get the match group dictionary
+    info = match.groupdict()
+    # set the branch name
+    table["local"] = info["branch"]
+    # all done
+    return table
+
+
+def gitMoved(table, match):
+    """
+    Compute the number of moved files
+    """
+    # all done
+    return table
+
+
+def gitChanged(table, match):
+    """
+    Compute the number of changed files
+    """
+    # get the match group dictionary
+    info = match.groupdict()
+    # get the code
+    code = info["CODE"]
+
+    # if this is an untracked file
+    if code in gitUntracked:
+        # all done
+        return table
+
+    # if this is an ignored file
+    if code in gitIgnored:
+        # all done
+        return table
+
+    # if this is a conflict indicator
+    if code in gitConflicts:
+        # update the counter
+        table["conflicts"] += 1
+        # all done
+        return table
+
+    # if the code has any info on the index side
+    if code[0] != " ":
+        # update the index count
+        table["index"] += 1
+
+    # if the code has any info on the worktree side
+    if code[1] != " ":
+        table["worktree"] += 1
+
+    # all done
+    return table
+
+
+# the regex
+gitParser = re.compile(
+    "|".join(
+        [
+            # brand new repositories without any commits
+            r"(?P<no_commits>## No commits yet on (?P<new>.+))$",
+            # detached HEAD
+            r"(?P<detached>## HEAD \(no branch\))$",
+            # repositories at a known branch that tack a remote
+            r"(?P<tracking>## " +
+            # the local branch name
+            r"(?P<local>.+)" +
+            # the separator
+            r"\.\.\." +
+            # the remote info
+            r"(" +
+            # the remote branch name
+            r"(?P<remote>[^\s]+)" +
+            # divergence information
+            r"("
+            + r" \[(ahead (?P<ahead>\d+))?(, )?(behind (?P<behind>\d+))?\]"
+            + r")?"
+            + r")?"
+            + r")$",
+            # no remote repository
+            r"(?P<non_tracking>## (?P<branch>.+))$",
+            # files that have been copied/renamed
+            r"(?P<moved>(?P<code>..) (?P<source>.+) -> (?P<destination>.+))$",
+            # files with modifications
+            r"(?P<changed>(?P<CODE>..) (?P<filename>.+))$",
+        ]
+    )
+)
+
+
+# dispatch table
+gitDispatcher = {
+    "no_commits": gitNoCommits,
+    "detached": gitDetached,
+    "tracking": gitTracking,
+    "non_tracking": gitLocal,
+    "moved": gitMoved,
+    "changed": gitChanged,
+}
+
+
+# git status code sets
+gitUntracked = {"??"}
+gitIgnored = {"!!"}
+gitConflicts = {"DD", "AU", "UD", "UA", "DU", "AA", "UU"}
+
+
+# utilities
+def finalize(cwd):
+    """
+    Add the trailing bit
+    """
+    # render
+    yield f"{normal}{cwd}>"
+    # all done
+    return
+
+
+def decorateWindow(cwd):
+    """
+    Decorate an xterm window
+    """
+    # get the terminal type
+    term = os.getenv("TERM", "")
+    # if it's not xterm compatible
+    if not term.startswith("xterm"):
+        # bail
+        return
+    # otherwise, get the user name
+    username = os.getenv("USER", "")
+    # get the hostname; the login process discovers and sets this
+    hostname = "@INSTANCE@"
+    # assemble the title
+    title = f"{username}@{hostname}:{cwd}"
+
+    # decorate the window
+    yield rl_hide + ascii_esc + f"]0;{title}" + ascii_bel + rl_unhide
+
+    # all done
+    return
+
+
+def getcwd():
+    """
+    Build a nice representation of the current working directory
+    """
+    # get the current working directory
+    cwd = os.environ["PWD"]
+    # and the user's home
+    home = os.environ["HOME"]
+    # if the current working directory is a subdirectory of the user's home
+    if cwd.startswith(home):
+        # replace the leading part with a '~'
+        cwd = "~" + cwd[len(home) :]
+    # all done
+    return cwd
+
+
+# color generators
+def csi3(code):
+    """
+    Make a control sequence for the given color code
+    """
+    # easy wnough
+    return f"{rl_hide}{ascii_esc}[{code}m{rl_unhide}"
+
+
+def csi24(red, green, blue):
+    """
+    Make a control sequence for the given color
+    """
+    # easy enough
+    return f"{rl_hide}{ascii_esc}[38;2;{red};{green};{blue}m{rl_unhide}"
+
+
+# constants
+# ascii codes
+ascii_nul = "\x00"
+ascii_soh = "\x01"
+ascii_stx = "\x02"
+ascii_etx = "\x03"
+ascii_eot = "\x04"
+ascii_enq = "\x05"
+ascii_ack = "\x06"
+ascii_bel = "\x07"
+ascii_bs = "\x08"
+ascii_tab = "\x09"
+ascii_lf = "\x0a"
+ascii_vt = "\x0b"
+ascii_ff = "\x0c"
+ascii_cr = "\x0d"
+ascii_so = "\x0e"
+ascii_si = "\x0f"
+ascii_esc = "\x1b"
+ascii_del = "\x7f"
+
+# readline hidden characters escapes
+rl_hide = "%{" if isZSH else ascii_soh
+rl_unhide = "%}" if isZSH else ascii_stx
+
+# colors
+# ansi
+normal = csi3(code=0)
+
+# 24bit
+amber = csi24(red=255, green=191, blue=0)
+burlywood = csi24(red=0xDE, green=0xB8, blue=0x87)
+dark_goldenrod = csi24(red=0xB8, green=0x86, blue=0x0B)
+dark_khaki = csi24(red=0xBD, green=0xB7, blue=0x6B)
+dark_orange = csi24(red=0xFF, green=0x8C, blue=0x00)
+dark_sea_green = csi24(red=0x8F, green=0xBC, blue=0x8F)
+firebrick = csi24(red=0xB2, green=0x22, blue=0x22)
+gray10 = csi24(red=0x19, green=0x19, blue=0x19)
+gray30 = csi24(red=0x4C, green=0x4C, blue=0x4C)
+gray41 = csi24(red=0x69, green=0x69, blue=0x69)
+gray50 = csi24(red=0x80, green=0x80, blue=0x80)
+gray66 = csi24(red=169, green=169, blue=169)
+gray75 = csi24(red=0xBE, green=0xBE, blue=0xBE)
+hot_pink = csi24(red=0xFF, green=0x69, blue=0xB4)
+indian_red = csi24(red=0xCD, green=0x5C, blue=0x5C)
+lavender = csi24(red=192, green=176, blue=224)
+light_green = csi24(red=0x90, green=0xEE, blue=0x90)
+light_steel_blue = csi24(red=0xB0, green=0xC4, blue=0xDE)
+lime_green = csi24(red=0x32, green=0xCD, blue=0x32)
+navajo_white = csi24(red=0xFF, green=0xDE, blue=0xAD)
+olive_drab = csi24(red=0x6B, green=0x8E, blue=0x23)
+peach_puff = csi24(red=0xFF, green=0xDA, blue=0xB9)
+sage = csi24(red=176, green=208, blue=176)
+steel_blue = csi24(red=70, green=130, blue=180)
+
+# functional
+# prompt
+prompt_normal = gray41
+# branch
+branch_ahead = prompt_normal
+branch_behind = prompt_normal
+branch_clean = olive_drab
+branch_modified = indian_red
+branch_modified_worktree = amber
+branch_modified_index = dark_sea_green
+branch_conflicts = firebrick
+# virtual environment
+venv_python = dark_sea_green
+venv_conda = steel_blue
+
+
+# bootstrap
+if __name__ == "__main__":
+    # generate the prompt
+    status = prompt()
+    # and share the status with the shell
+    raise SystemExit(status)
+
+
+# end of file

--- a/examples/hello/pkg/hello/__init__.py
+++ b/examples/hello/pkg/hello/__init__.py
@@ -20,7 +20,7 @@ from pyre import (
 )
 
 # bootstrap
-package = executive.registerPackage(name='nisar', file=__file__)
+package = executive.registerPackage(name='hello', file=__file__)
 # save the geography
 home, prefix, defaults = package.layout()
 

--- a/examples/hello/pkg/hello/cli/__init__.py
+++ b/examples/hello/pkg/hello/cli/__init__.py
@@ -38,7 +38,7 @@ def config():
 
 # hello
 @foundry(implements=action, tip="compute the result of an operation")
-def hello():
+def greet():
     """
     Say "hello" to a friend
     """

--- a/examples/hello/pkg/hello/meta.py.in
+++ b/examples/hello/pkg/hello/meta.py.in
@@ -19,17 +19,19 @@ version = (major, minor, micro, revision)
 
 
 # decorations for the help system
-copyright = "copyright (c) 1998-YEAR all rights reserved"
+copyright = "copyright (c) 1998-@YEAR@ all rights reserved"
 
 banner = f"""
     hello {major}.{minor}.{micro} revision {revision}
     {copyright}
 """
 
-header = banner + """
+authors = """
 authors:
     michael a.g. aïvázis <michael.aivazis@para-sim.com>
 """
+
+header = banner + authors
 
 license = header + """
 license:

--- a/examples/hello/pkg/hello/shells/Plexus.py
+++ b/examples/hello/pkg/hello/shells/Plexus.py
@@ -6,6 +6,8 @@
 #
 
 
+# externals
+import textwrap
 # access the pyre framework
 import pyre
 # and my package
@@ -32,6 +34,20 @@ class Plexus(pyre.plexus, family='hello.components.plexus'):
         """
         # show the license header
         return hello.meta.header
+
+   # support for the help system
+    def pyre_banner(self):
+        """
+        Generate the help banner
+        """
+        # the project header
+        yield from textwrap.dedent(hello.meta.banner).splitlines()
+        # the doc string
+        yield from self.pyre_showSummary(indent="")
+        # the authors
+        yield from textwrap.dedent(hello.meta.authors).splitlines()
+        # all done
+        return
 
 
     # interactive session management

--- a/make/compilers/clang/flang.mm
+++ b/make/compilers/clang/flang.mm
@@ -22,8 +22,8 @@ flang.prefix.rpath := -Wl,-rpath,
 flang.prefix.libraries := -l
 
 # compile time flags
-# VERIFY: -pipe is likely fine for flang-new (LLVM infrastructure) but not confirmed
-flang.compile.base := -pipe
+# flang has no {-pipe}; leave the base empty
+flang.compile.base :=
 flang.compile.only := -c
 flang.compile.output := -o
 flang.compile.makedep :=
@@ -63,10 +63,7 @@ flang.mixed.defines ?=
 flang.mixed.incpath ?=
 flang.mixed.ldflags ?=
 flang.mixed.libpath ?=
-# VERIFY: runtime library name depends heavily on the flang distribution:
-#   flang-new (LLVM 16+): FortranRuntime and possibly FortranDecimal
-#   classic flang (PGI/conda): flang
-flang.mixed.libraries += FortranRuntime
+flang.mixed.libraries += flang_rt.runtime
 
 # dependency generation
 # flang cannot generate dependencies (leave empty; revisit if flang-new gains -MD support)


### PR DESCRIPTION
## Summary

Make the LLVM **flang** Fortran compiler usable under mm and prove it end-to-end by building
the `hello` example (mixed C/C++/Fortran) on a real linux64 box.

## flang compiler support (`make/compilers/clang/flang.mm`)

- Drop `-pipe` from `flang.compile.base` — flang does not accept it.
- Point `flang.mixed.libraries` at **`flang_rt.runtime`** (`libflang_rt.runtime.so`), the
  LLVM Flang-RT runtime, replacing the stale `FortranRuntime` name. This is what supplies
  symbols like `_FortranAAssign` when a **non-Fortran compiler drives the link** of a target
  that contains Fortran objects.

## Installing flang from conda-forge

To get a functioning flang toolchain, install:

- **`flang`** — the compiler. Provides the plain `flang` driver on `PATH` (`bin/flang`),
  the compiler libraries, headers, and `libFortranDecimal`. **This package is
  compiler-only — it does not include the runtime.**
- **`libflang-rt`** — the LLVM Flang-RT runtime (`libflang_rt.runtime.so`), which defines the
  `_FortranA*` symbol namespace (e.g. `_FortranAAssign`). Required to link any program with
  Fortran objects; without it the link fails with unresolved `_FortranA*` symbols.

```yaml
dependencies:
  - clang
  - clangxx
  - flang
  - libflang-rt
```

Notes:
- conda-forge ships flang for **linux-64** and **win-64** only — there is no osx/aarch64 build.
- Do **not** rely on `flang_linux-64` for mm. That is the autotools/cmake activation
  metapackage (gcc_linux-64 analogue): it sets `FC`/sysroot env, ships an empty `bin/`, and
  drags in `clangdev` + `compiler-rt_linux-64`. mm invokes the plain `flang` driver directly
  (`flang.driver := flang`) and ignores conda's activation, so `flang` + `libflang-rt` is the
  correct, minimal set.

## linux64 test harness (`examples/hello/etc/docker/questing-clang/`)

A docker image, modeled on `qef/etc/docker` and trimmed to hello, for building and testing
the example on linux64 at will:

- `ubuntu:questing` + micromamba env with the clang/flang toolchain (per above) and hello's deps.
- `mm.yaml` leans on the new support: `mode: conda` (no `prefix`/`bldroot`/`pycPrefix`) and
  `pkgdb: conda` (no external package database); `config.mm` is therefore empty.
- Wired into mm via `hello.docker-images := hello.questing-clang` + `include` in `hello.mm`.
  Because hello lives inside the mm repo, the image mounts the whole repo (build tool +
  example); `mounts.source` uses deferred (`=`) expansion so it survives `-warn-undefined`.

## hello example wiring

- `hello.lib.extern := pyre fortran` — the `fortran` extern is mm's mixed-language seam; it
  injects `flang.mixed.libraries` into the clang++-driven link of the library carrying
  `mat.f03`, resolving the Fortran runtime symbols.

## Validation

Builds and tests clean on a real linux64 machine.

_Note: this branch also carries a few unrelated `examples/hello` repairs (package meta, a
registration typo, the plexus banner, a cli/package-name collision) that are incidental to
flang support._