### PR TITLE
The make layer is now aware of the build mode

### DIFF
--- a/make/merlin.mm
+++ b/make/merlin.mm
@@ -19,7 +19,7 @@ config.db += ${if $(user.environment),$(user.environment) $(user.environment)@$(
 # projects can now declare new asset types and provide support for them in their {mm}
 # configuration directory
 define model :=
-    log mm
+    log mm modes
     languages platforms hosts users developers
     compilers targets builder runners toolchains
 	extern projects

--- a/make/mm/rules.mm
+++ b/make/mm/rules.mm
@@ -24,6 +24,7 @@ help mm.usage: | mm.banner
 	@$(log) "for details about the build, try one of the following targets:"
 	@$(log)
 	@${call log.help,"  projects.info","information about the known projects"}
+	@${call log.help,"      mode.info","the current build mode and its settings"}
 	@${call log.help,"  platform.info","platform specific options"}
 	@${call log.help," compilers.info","the list of active compilers"}
 	@${call log.help,"  suffixes.info","a map from file suffixes to compilers"}

--- a/make/modes/conda.mm
+++ b/make/modes/conda.mm
@@ -4,8 +4,7 @@
 # (c) 1998-2026 all rights reserved
 
 
-# {conda} pins dependencies to the committed lock
-mode.npm.locked := yes
+# {conda} inherits the baseline and overrides nothing
 
 
 # end of file

--- a/make/modes/conda.mm
+++ b/make/modes/conda.mm
@@ -1,0 +1,11 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# {conda} pins dependencies to the committed lock
+mode.npm.locked := yes
+
+
+# end of file

--- a/make/modes/default.mm
+++ b/make/modes/default.mm
@@ -4,10 +4,10 @@
 # (c) 1998-2026 all rights reserved
 
 
-# the baseline value of every mode-dependent knob, grouped by consumer
+# the baseline (non-dev) value of every mode-dependent knob, grouped by consumer
 
 # npm: empty installs fresh ({npm i}); non-empty installs from the committed lock ({npm ci})
-mode.npm.locked :=
+mode.npm.locked := yes
 
 
 # end of file

--- a/make/modes/default.mm
+++ b/make/modes/default.mm
@@ -1,0 +1,13 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# the baseline value of every mode-dependent knob, grouped by consumer
+
+# npm: empty installs fresh ({npm i}); non-empty installs from the committed lock ({npm ci})
+mode.npm.locked :=
+
+
+# end of file

--- a/make/modes/dev.mm
+++ b/make/modes/dev.mm
@@ -4,7 +4,8 @@
 # (c) 1998-2026 all rights reserved
 
 
-# {dev} inherits the baseline and overrides nothing
+# {dev} resolves dependencies fresh rather than from the committed lock
+mode.npm.locked :=
 
 
 # end of file

--- a/make/modes/dev.mm
+++ b/make/modes/dev.mm
@@ -1,0 +1,10 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# {dev} inherits the baseline and overrides nothing
+
+
+# end of file

--- a/make/modes/init.mm
+++ b/make/modes/init.mm
@@ -1,0 +1,16 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# the baseline shared by every mode
+include make/modes/default.mm
+# the selected mode's overrides; a mode with no file here is a fatal error
+include make/modes/$(project.mode).mm
+
+# the implemented modes, discovered from the files present here, minus the framework files
+modes.available := ${filter-out init default rules model,${basename ${notdir ${wildcard $(mm.home)/make/modes/*.mm}}}}
+
+
+# end of file

--- a/make/modes/macports.mm
+++ b/make/modes/macports.mm
@@ -1,0 +1,11 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# {macports} pins dependencies to the committed lock
+mode.npm.locked := yes
+
+
+# end of file

--- a/make/modes/macports.mm
+++ b/make/modes/macports.mm
@@ -4,8 +4,7 @@
 # (c) 1998-2026 all rights reserved
 
 
-# {macports} pins dependencies to the committed lock
-mode.npm.locked := yes
+# {macports} inherits the baseline and overrides nothing
 
 
 # end of file

--- a/make/modes/release.mm
+++ b/make/modes/release.mm
@@ -1,0 +1,11 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# {release} pins dependencies to the committed lock
+mode.npm.locked := yes
+
+
+# end of file

--- a/make/modes/release.mm
+++ b/make/modes/release.mm
@@ -4,8 +4,7 @@
 # (c) 1998-2026 all rights reserved
 
 
-# {release} pins dependencies to the committed lock
-mode.npm.locked := yes
+# {release} inherits the baseline and overrides nothing
 
 
 # end of file

--- a/make/modes/rules.mm
+++ b/make/modes/rules.mm
@@ -1,0 +1,33 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# the current build mode and the settings it resolves to
+mode.info:
+	@${call log.sec,"mode","the build mode and its resolved settings"}
+	@${call log.var,current,$(project.mode)}
+	@${call log.var,available,$(modes.available)}
+	@${call log.sec,"  npm",}
+	@${call log.var,locked,$(mode.npm.locked)}
+
+# what the build mode controls and the values it can take
+mode.help: | mm.banner
+	@$(log) "the build mode tunes what the make layer does per deployment target"
+	@$(log)
+	@$(log) "select one on the command line, e.g."
+	@$(log)
+	@$(log) "    mm --mode=release"
+	@$(log)
+	@${call log.help,"mode.info","show the current mode and its resolved settings"}
+	@$(log)
+	@${call log.sec,"available modes",}
+	@${foreach mode,$(modes.available),$(log) $(log.indent)$(mode);}
+	@$(log)
+	@${call log.sec,"settings",}
+	@${call log.help,"mode.npm.locked","install npm deps from the committed lock when set (otherwise resolve fresh)"}
+	@$(log)
+
+
+# end of file

--- a/make/modes/ubuntu.mm
+++ b/make/modes/ubuntu.mm
@@ -4,8 +4,7 @@
 # (c) 1998-2026 all rights reserved
 
 
-# {ubuntu} pins dependencies to the committed lock
-mode.npm.locked := yes
+# {ubuntu} inherits the baseline and overrides nothing
 
 
 # end of file

--- a/make/modes/ubuntu.mm
+++ b/make/modes/ubuntu.mm
@@ -1,0 +1,11 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# {ubuntu} pins dependencies to the committed lock
+mode.npm.locked := yes
+
+
+# end of file

--- a/make/vite/init.mm
+++ b/make/vite/init.mm
@@ -65,6 +65,7 @@ define vite.init
     # the various files by category
     ${eval $(_bundle).config.index ?= index.html}
     ${eval $(_bundle).config.npm ?= package.json}
+    ${eval $(_bundle).config.npm_lock ?= package-lock.json}
     ${eval $(_bundle).config.ts ?= tsconfig.node.json tsconfig.json}
     ${eval $(_bundle).config.vite ?= vite.config.ts .eslintrc.cjs}
     ${eval $(_bundle).config.extra ?=}
@@ -89,6 +90,12 @@ define vite.init
     ${eval $(_bundle).stage.modules ?= $($(_bundle).staging.prefix)node_modules/}
     # where vite writes its production bundle, relative to the staging root
     ${eval $(_bundle).staging.dist ?= $($(_bundle).staging.prefix)dist/}
+
+    # the npm configuration file and the committed dependency lock
+    ${eval $(_bundle).source.npm_config ?= $($(_bundle).config.prefix)$($(_bundle).config.npm)}
+    ${eval $(_bundle).source.npm_lock ?= $($(_bundle).config.prefix)$($(_bundle).config.npm_lock)}
+    ${eval $(_bundle).staging.npm_config ?= $($(_bundle).staging.prefix)$($(_bundle).config.npm)}
+    ${eval $(_bundle).staging.npm_lock ?= $($(_bundle).staging.prefix)$($(_bundle).config.npm_lock)}
 
     # the graphql strategy: none | relay | houdini; selects the codegen step mm runs
     ${eval $(_bundle).graphql ?= none}
@@ -125,15 +132,17 @@ define vite.init
     $(_bundle).metadoc.source.static.present := "directories with static assets"
 
     # sources: infromation about the sources
-    $(_bundle).meta.source := source.npm_config
+    $(_bundle).meta.source := source.npm_config source.npm_lock
     # document each one
     $(_bundle).metadoc.source.npm_config := "the npm configuration file; typically called 'package.json'"
+    $(_bundle).metadoc.source.npm_lock := "the committed dependency lock; staged in non-dev modes"
 
     # staging: the list of attributes
-    $(_bundle).meta.staging := staging.prefix staging.npm_config
+    $(_bundle).meta.staging := staging.prefix staging.npm_config staging.npm_lock
     # document each one
     $(_bundle).metadoc.staging.prefix := "the root of the staging directory"
     $(_bundle).metadoc.staging.npm_config := "the npm configuration file"
+    $(_bundle).metadoc.staging.npm_lock := "the dependency lock in the staging area"
 
     # install: the list of attributes
     $(_bundle).meta.install := install.prefix

--- a/make/vite/rules.mm
+++ b/make/vite/rules.mm
@@ -83,16 +83,16 @@ $(_bundle).stage.modules: $($(_bundle).stage.modules)
 # and its implementation, selected by the build mode
 ${eval ${call $(vite.npm.install),$(_bundle)}}
 
-# force a clean install from the committed lock; recovers from npm instability in {dev}
-$(_bundle).lock: $(_bundle).stage.config | $($(_bundle).staging.prefix)
+# seed a clean install from the committed lock; recovers from npm instability in {dev}
+$(_bundle).lock.seed: $(_bundle).stage.config | $($(_bundle).staging.prefix)
 	@test -f $($(_bundle).source.npm_lock) || { ${call log.error,no committed lock to install from}; false; }
 	@${call log.action,"cp",$($(_bundle).config.npm_lock)}
 	$(cp) $($(_bundle).source.npm_lock) $($(_bundle).staging.npm_lock)
 	@${call log.action,"npm ci",$(_bundle)}
 	$(cd) $($(_bundle).staging.prefix); npm ci
 
-# promote the resolved staging lock back to the source tree for committing
-$(_bundle).lock.update:
+# harvest the freshly-resolved lock back to the source tree for committing
+$(_bundle).lock.harvest:
 	@${call log.action,"cp",$($(_bundle).config.npm_lock)}
 	$(cp) $($(_bundle).staging.npm_lock) $($(_bundle).source.npm_lock)
 

--- a/make/vite/rules.mm
+++ b/make/vite/rules.mm
@@ -80,10 +80,21 @@ $(_bundle).stage.files::
 
 # the rule that installs/updates the node modules
 $(_bundle).stage.modules: $($(_bundle).stage.modules)
-# and its implementation
-$($(_bundle).stage.modules): $($(_bundle).config.prefix)$($(_bundle).config.npm) | $($(_bundle).staging.prefix)
-	@${call log.action,"npm",$($(_bundle).config.npm)}
-	$(cd) $($(_bundle).staging.prefix); npm install
+# and its implementation, selected by the build mode
+${eval ${call $(vite.npm.install),$(_bundle)}}
+
+# force a clean install from the committed lock; recovers from npm instability in {dev}
+$(_bundle).lock: $(_bundle).stage.config | $($(_bundle).staging.prefix)
+	@test -f $($(_bundle).source.npm_lock) || { ${call log.error,no committed lock to install from}; false; }
+	@${call log.action,"cp",$($(_bundle).config.npm_lock)}
+	$(cp) $($(_bundle).source.npm_lock) $($(_bundle).staging.npm_lock)
+	@${call log.action,"npm ci",$(_bundle)}
+	$(cd) $($(_bundle).staging.prefix); npm ci
+
+# promote the resolved staging lock back to the source tree for committing
+$(_bundle).lock.update:
+	@${call log.action,"cp",$($(_bundle).config.npm_lock)}
+	$(cp) $($(_bundle).staging.npm_lock) $($(_bundle).source.npm_lock)
 
 # make the rules that copy the configuration files to the staging area
 ${foreach file,
@@ -129,6 +140,31 @@ $($(_bundle).staging.prefix): | $($($(_bundle).project).tmpdir)
 
 # all done
 endef
+
+
+# stage the npm config (via the config rules), then resolve dependencies fresh
+define vite.npm.install.fresh =
+$($(1).stage.modules): $($(1).source.npm_config) | $($(1).staging.prefix)
+	@${call log.action,"npm i",$(1)}
+	$(cd) $($(1).staging.prefix); npm install
+# all done
+endef
+
+
+# stage the committed lock, then install exactly from it
+define vite.npm.install.locked =
+$($(1).staging.npm_lock): $($(1).source.npm_lock) | $($(1).staging.prefix)
+	@${call log.action,"cp",$($(1).config.npm_lock)}
+	$(cp) $($(1).source.npm_lock) $($(1).staging.npm_lock)
+$($(1).stage.modules): $($(1).source.npm_config) $($(1).staging.npm_lock) | $($(1).staging.prefix)
+	@${call log.action,"npm ci",$(1)}
+	$(cd) $($(1).staging.prefix); npm ci
+# all done
+endef
+
+
+# the install strategy selected by the build mode
+vite.npm.install := vite.npm.install.${if $(mode.npm.locked),locked,fresh}
 
 
 # rule factory for creating individual staging source directories

--- a/make/webpack/init.mm
+++ b/make/webpack/init.mm
@@ -43,6 +43,7 @@ define webpack.init
     # the configuration files
     ${eval $(2).source.page ?= $($(2).prefix)$($(2).name).html}
     ${eval $(2).source.npm_config ?= $($(2).prefix)$($(2).config)package.json}
+    ${eval $(2).source.npm_lock ?= $($(2).prefix)$($(2).config)package-lock.json}
     ${eval $(2).source.babel_config ?= $($(2).prefix)$($(2).config)babelrc}
     ${eval $(2).source.webpack_config ?= $($(2).prefix)$($(2).config)webpack.js}
     ${eval $(2).source.ts_config ?= $($(2).prefix)$($(2).config)tsconfig.json}
@@ -55,6 +56,7 @@ define webpack.init
     ${eval $(2).staging.prefix.generated ?= $($(2).staging.prefix)build/}
     ${eval $(2).staging.page ?= $($(2).staging.prefix)$($(2).name).html}
     ${eval $(2).staging.npm_config ?= $($(2).staging.prefix)package.json}
+    ${eval $(2).staging.npm_lock ?= $($(2).staging.prefix)package-lock.json}
     ${eval $(2).staging.babel_config ?= $($(2).staging.prefix).babelrc}
     ${eval $(2).staging.webpack_config ?= $($(2).staging.prefix)webpack.config.js}
     ${eval $(2).staging.ts_config ?= $($(2).staging.prefix)tsconfig.json}
@@ -121,15 +123,17 @@ define webpack.init
     $(2).metadoc.source.static.present := "directories with static assets"
 
     # sources: infromation about the sources
-    $(2).meta.source := source.npm_config
+    $(2).meta.source := source.npm_config source.npm_lock
     # document each one
     $(2).metadoc.source.npm_config := "the npm configuration file; typically called 'package.json'"
+    $(2).metadoc.source.npm_lock := "the committed dependency lock; staged in non-dev modes"
 
     # staging: the list of attributes
-    $(2).meta.staging := staging.prefix staging.npm_config
+    $(2).meta.staging := staging.prefix staging.npm_config staging.npm_lock
     # document each one
     $(2).metadoc.staging.prefix := "the root of the staging directory"
     $(2).metadoc.staging.npm_config := "the npm configuration file"
+    $(2).metadoc.staging.npm_lock := "the dependency lock in the staging area"
 
     # install: the list of attributes
     $(2).meta.install := install.prefix

--- a/make/webpack/init.mm
+++ b/make/webpack/init.mm
@@ -57,6 +57,7 @@ define webpack.init
     ${eval $(2).staging.page ?= $($(2).staging.prefix)$($(2).name).html}
     ${eval $(2).staging.npm_config ?= $($(2).staging.prefix)package.json}
     ${eval $(2).staging.npm_lock ?= $($(2).staging.prefix)package-lock.json}
+    ${eval $(2).staging.modules ?= $($(2).staging.prefix)node_modules/}
     ${eval $(2).staging.babel_config ?= $($(2).staging.prefix).babelrc}
     ${eval $(2).staging.webpack_config ?= $($(2).staging.prefix)webpack.config.js}
     ${eval $(2).staging.ts_config ?= $($(2).staging.prefix)tsconfig.json}

--- a/make/webpack/rules.mm
+++ b/make/webpack/rules.mm
@@ -94,16 +94,16 @@ $($(1).staging.npm_config): $($(1).source.npm_config) | $($(1).staging.prefix)
 # install the node modules, keyed on the {node_modules} dir so a missing install re-runs
 ${eval ${call $(webpack.npm.install),$(1)}}
 
-# force a clean install from the committed lock; recovers from npm instability in {dev}
-$(1).lock: $($(1).staging.npm_config) | $($(1).staging.prefix)
+# seed a clean install from the committed lock; recovers from npm instability in {dev}
+$(1).lock.seed: $($(1).staging.npm_config) | $($(1).staging.prefix)
 	@test -f $($(1).source.npm_lock) || { ${call log.error,no committed lock to install from}; false; }
 	@${call log.action,"cp",${subst $($(1).prefix),,$($(1).source.npm_lock)}}
 	$(cp) $($(1).source.npm_lock) $($(1).staging.npm_lock)
 	@${call log.action,"npm ci",$(1)}
 	$(cd) $($(1).staging.prefix); npm ci
 
-# promote the resolved staging lock back to the source tree for committing
-$(1).lock.update:
+# harvest the freshly-resolved lock back to the source tree for committing
+$(1).lock.harvest:
 	@${call log.action,"cp",${subst $($(1).staging.prefix),,$($(1).staging.npm_lock)}}
 	$(cp) $($(1).staging.npm_lock) $($(1).source.npm_lock)
 

--- a/make/webpack/rules.mm
+++ b/make/webpack/rules.mm
@@ -78,7 +78,7 @@ $(1).config: \
 $(1).sources: $($(1).staging.app.sources)
 
 # install the dependencies
-$(1).npm_modules: $($(1).staging.npm_config)
+$(1).npm_modules: $($(1).staging.modules)
 
 
 # the main page where the bundle gets injected
@@ -86,14 +86,17 @@ $($(1).staging.page): $($(1).source.page) | $($(1).staging.prefix)
 	@${call log.action,"cp", $${subst $($(1).prefix),,$$<}}
 	$(cp) $$< $$@
 
-# stage the npm config and install dependencies; the strategy depends on the build mode
+# stage the npm configuration file
+$($(1).staging.npm_config): $($(1).source.npm_config) | $($(1).staging.prefix)
+	@${call log.action,"cp",${subst $($(1).prefix),,$($(1).source.npm_config)}}
+	$(cp) $($(1).source.npm_config) $($(1).staging.npm_config)
+
+# install the node modules, keyed on the {node_modules} dir so a missing install re-runs
 ${eval ${call $(webpack.npm.install),$(1)}}
 
 # force a clean install from the committed lock; recovers from npm instability in {dev}
-$(1).lock: | $($(1).staging.prefix)
+$(1).lock: $($(1).staging.npm_config) | $($(1).staging.prefix)
 	@test -f $($(1).source.npm_lock) || { ${call log.error,no committed lock to install from}; false; }
-	@${call log.action,"cp",${subst $($(1).prefix),,$($(1).source.npm_config)}}
-	$(cp) $($(1).source.npm_config) $($(1).staging.npm_config)
 	@${call log.action,"cp",${subst $($(1).prefix),,$($(1).source.npm_lock)}}
 	$(cp) $($(1).source.npm_lock) $($(1).staging.npm_lock)
 	@${call log.action,"npm ci",$(1)}
@@ -180,24 +183,21 @@ endef
 
 
 # helpers
-# stage the npm config, then resolve dependencies fresh from {package.json}
+# install the node modules fresh from {package.json}
 define webpack.npm.install.fresh =
-$($(1).staging.npm_config): $($(1).source.npm_config) | $($(1).staging.prefix)
-	@${call log.action,"cp",${subst $($(1).prefix),,$($(1).source.npm_config)}}
-	$(cp) $($(1).source.npm_config) $($(1).staging.npm_config)
+$($(1).staging.modules): $($(1).staging.npm_config) | $($(1).staging.prefix)
 	@${call log.action,"npm i",$(1)}
 	$(cd) $($(1).staging.prefix); npm i
 # all done
 endef
 
 
-# stage the npm config and the committed lock, then install exactly from the lock
+# stage the committed lock, then install the node modules exactly from it
 define webpack.npm.install.locked =
-$($(1).staging.npm_config): $($(1).source.npm_config) $($(1).source.npm_lock) | $($(1).staging.prefix)
-	@${call log.action,"cp",${subst $($(1).prefix),,$($(1).source.npm_config)}}
-	$(cp) $($(1).source.npm_config) $($(1).staging.npm_config)
+$($(1).staging.npm_lock): $($(1).source.npm_lock) | $($(1).staging.prefix)
 	@${call log.action,"cp",${subst $($(1).prefix),,$($(1).source.npm_lock)}}
 	$(cp) $($(1).source.npm_lock) $($(1).staging.npm_lock)
+$($(1).staging.modules): $($(1).staging.npm_config) $($(1).staging.npm_lock) | $($(1).staging.prefix)
 	@${call log.action,"npm ci",$(1)}
 	$(cd) $($(1).staging.prefix); npm ci
 # all done

--- a/make/webpack/rules.mm
+++ b/make/webpack/rules.mm
@@ -86,12 +86,23 @@ $($(1).staging.page): $($(1).source.page) | $($(1).staging.prefix)
 	@${call log.action,"cp", $${subst $($(1).prefix),,$$<}}
 	$(cp) $$< $$@
 
-# the npm configuration file lives at top level in the staging area
-$($(1).staging.npm_config): $($(1).source.npm_config) | $($(1).staging.prefix)
-	@${call log.action,"cp", $${subst $($(1).prefix),,$$<}}
-	$(cp) $$< $$@
-	@${call log.action,"npm", $${subst $($(1).staging.prefix),,$$@}}
-	$(cd) $($(1).staging.prefix); npm i
+# stage the npm config and install dependencies; the strategy depends on the build mode
+${eval ${call $(webpack.npm.install),$(1)}}
+
+# force a clean install from the committed lock; recovers from npm instability in {dev}
+$(1).lock: | $($(1).staging.prefix)
+	@test -f $($(1).source.npm_lock) || { ${call log.error,no committed lock to install from}; false; }
+	@${call log.action,"cp",${subst $($(1).prefix),,$($(1).source.npm_config)}}
+	$(cp) $($(1).source.npm_config) $($(1).staging.npm_config)
+	@${call log.action,"cp",${subst $($(1).prefix),,$($(1).source.npm_lock)}}
+	$(cp) $($(1).source.npm_lock) $($(1).staging.npm_lock)
+	@${call log.action,"npm ci",$(1)}
+	$(cd) $($(1).staging.prefix); npm ci
+
+# promote the resolved staging lock back to the source tree for committing
+$(1).lock.update:
+	@${call log.action,"cp",${subst $($(1).staging.prefix),,$($(1).staging.npm_lock)}}
+	$(cp) $($(1).staging.npm_lock) $($(1).source.npm_lock)
 
 # so does the babel configuration file
 $($(1).staging.babel_config): $($(1).source.babel_config) | $($(1).staging.prefix)
@@ -169,6 +180,34 @@ endef
 
 
 # helpers
+# stage the npm config, then resolve dependencies fresh from {package.json}
+define webpack.npm.install.fresh =
+$($(1).staging.npm_config): $($(1).source.npm_config) | $($(1).staging.prefix)
+	@${call log.action,"cp",${subst $($(1).prefix),,$($(1).source.npm_config)}}
+	$(cp) $($(1).source.npm_config) $($(1).staging.npm_config)
+	@${call log.action,"npm i",$(1)}
+	$(cd) $($(1).staging.prefix); npm i
+# all done
+endef
+
+
+# stage the npm config and the committed lock, then install exactly from the lock
+define webpack.npm.install.locked =
+$($(1).staging.npm_config): $($(1).source.npm_config) $($(1).source.npm_lock) | $($(1).staging.prefix)
+	@${call log.action,"cp",${subst $($(1).prefix),,$($(1).source.npm_config)}}
+	$(cp) $($(1).source.npm_config) $($(1).staging.npm_config)
+	@${call log.action,"cp",${subst $($(1).prefix),,$($(1).source.npm_lock)}}
+	$(cp) $($(1).source.npm_lock) $($(1).staging.npm_lock)
+	@${call log.action,"npm ci",$(1)}
+	$(cd) $($(1).staging.prefix); npm ci
+# all done
+endef
+
+
+# the install strategy selected by the build mode
+webpack.npm.install := webpack.npm.install.${if $(mode.npm.locked),locked,fresh}
+
+
 define webpack.workflows.static.asset =
 
     # local variables

--- a/mm
+++ b/mm
@@ -106,7 +106,7 @@ class Builder(pyre.application, family="pyre.applications.mm", namespace="mm"):
     # compute branch-keyed build paths and print shell export statements
     mode = pyre.properties.str()
     mode.default = "dev"
-    mode.validators = pyre.constraints.isMember("dev", "conda", "macports", "ubuntu")
+    mode.validators = pyre.constraints.isMember("dev", "release", "conda", "macports", "ubuntu")
     mode.doc = "the strategy for generating locations for the build products"
 
     branch = pyre.properties.bool()
@@ -382,12 +382,14 @@ class Builder(pyre.application, family="pyre.applications.mm", namespace="mm"):
         # the mode dispatch tables
         self._bldrootDispatch = {
             "dev": self._devBldroot,
+            "release": self._releaseBldroot,
             "conda": self._condaBldroot,
             "macports": self._macportsBldroot,
             "ubuntu": self._ubuntuBldroot,
         }
         self._prefixDispatch = {
             "dev": self._devPrefix,
+            "release": self._releasePrefix,
             "conda": self._condaPrefix,
             "macports": self._macportsPrefix,
             "ubuntu": self._ubuntuPrefix,
@@ -1148,6 +1150,8 @@ class Builder(pyre.application, family="pyre.applications.mm", namespace="mm"):
         """
         # the project home
         yield f"project.home={self._root}"
+        # the build mode, so the make subsystem can gate behavior on {mode != dev}
+        yield f"project.mode={self.mode}"
         # the path to the mm configuration files
         yield f"project.config={self._projectCfg}"
         # the location to place the intermediate build products
@@ -1280,21 +1284,6 @@ class Builder(pyre.application, family="pyre.applications.mm", namespace="mm"):
         yield f"host.cores={host.cpus.cpus}"
         # all done
         return
-
-    def _fromCommandLine(self, name):
-        """
-        Test whether the value of the trait named {name} came from the command line, as opposed
-        to a config file, an environment-derived default, or the trait default. Only command-
-        line overrides are invisible to a recursively launched {mm}: the child runs in the same
-        directory and inherits the same environment, so it reproduces everything else on its own
-        """
-        # the trait descriptor
-        trait = self.pyre_trait(name)
-        # the priority of its current value records which configuration category assigned it
-        priority = self.pyre_inventory.getTraitPriority(trait)
-        # command-line assignments belong to the {command} category; this is the same idiom
-        # pyre itself uses to recognize a category (see framework/NameServer)
-        return priority.category == priority.command.category
 
     def relaunchArguments(self):
         """
@@ -1572,6 +1561,21 @@ class Builder(pyre.application, family="pyre.applications.mm", namespace="mm"):
     gitDescriptionParser = re.compile(
         r"(v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<micro>\d+)-(?P<ahead>\d+)-g)?(?P<commit>.+)"
     )
+
+    def _fromCommandLine(self, name):
+        """
+        Test whether the value of the trait named {name} came from the command line, as opposed
+        to a config file, an environment-derived default, or the trait default. Only command-
+        line overrides are invisible to a recursively launched {mm}: the child runs in the same
+        directory and inherits the same environment, so it reproduces everything else on its own
+        """
+        # the trait descriptor
+        trait = self.pyre_trait(name)
+        # the priority of its current value records which configuration category assigned it
+        priority = self.pyre_inventory.getTraitPriority(trait)
+        # command-line assignments belong to the {command} category; this is the same idiom
+        # pyre itself uses to recognize a category (see framework/NameServer)
+        return priority.category == priority.command.category
 
     def _buildAdhocPackageDatabase(self, db):
         """
@@ -2918,14 +2922,36 @@ class Builder(pyre.application, family="pyre.applications.mm", namespace="mm"):
         """
         Assemble the staging area path for a {dev} build
         """
+        # {dev} is the bare local layout, so it injects no mode discriminator
+        return self._localBldroot()
+
+    def _releaseBldroot(self):
+        """
+        Assemble the staging area path for a {release} build
+        """
+        # {release} is a local build that lives under its own discriminator so its
+        # artifacts never mix with the {dev} ones
+        return self._localBldroot(discriminator="release")
+
+    def _localBldroot(self, *, discriminator=None):
+        """
+        Assemble the staging area path for a local ({dev} or {release}) build
+        """
         # start with the user's opinion, falling back to the project tree
         bldroot = self.bldroot or (self._root / "builds")
-        # if a compiler suite is set, add it to the path to separate ABI-incompatible builds
+        # a non-{dev} local mode
+        if discriminator:
+            # keeps its products apart by carrying a discriminator
+            bldroot /= discriminator
+        # get the compiler suite
         suite = self._suite
+        # if it is set
         if suite:
+            # add it to the path to separate ABI-incompatible builds
             bldroot /= suite
-        # if a branch tag is set, use it to discriminate the build context
+        # get the branch tag
         tag = self.tag
+        # if it is set, use it to discriminate the build context
         if tag:
             # include the build variant so builds for different targets land separately
             return bldroot / tag / self._bldTag
@@ -2936,14 +2962,35 @@ class Builder(pyre.application, family="pyre.applications.mm", namespace="mm"):
         """
         Assemble the installation path for a {dev} build
         """
+        # {dev} is the bare local layout, so it injects no mode discriminator
+        return self._localPrefix()
+
+    def _releasePrefix(self):
+        """
+        Assemble the installation path for a {release} build
+        """
+        # {release} installs under its own discriminator so it never mixes with {dev}
+        return self._localPrefix(discriminator="release")
+
+    def _localPrefix(self, *, discriminator=None):
+        """
+        Assemble the installation path for a local ({dev} or {release}) build
+        """
         # start with the user's opinion, falling back to the project tree
         prefix = self.prefix or (self._root / "products")
-        # if a compiler suite is set, add it to the path to separate ABI-incompatible installs
+        # a non-{dev} local mode
+        if discriminator:
+            # keeps its installs apart by carrying a discriminator
+            prefix /= discriminator
+        # get the compiler suite
         suite = self._suite
+        # if a compiler suite is set
         if suite:
+            # add it to the path to separate ABI-incompatible installs
             prefix /= suite
-        # if a branch tag is set, use it to discriminate the build context
+        # get the tag
         tag = self.tag
+        # if a branch tag is set, use it to discriminate the build context
         if tag:
             # include the build variant so installs for different targets land separately
             return prefix / tag / self._bldTag


### PR DESCRIPTION
## Goal

Make `mode` a first-class build axis that drives **behavior**, not just build/install paths — so the make layer can do different things in `dev` vs deployment builds (`release`, `conda`, `macports`, `ubuntu`).

`mode` already existed in the driver as the deployment-intent axis (orthogonal to `target`, which governs compiler flags). This branch adds a local `release` mode, plumbs the mode through to make, builds a small framework for mode-dependent recipes, and lands the first consumers.

## Driver

- New `release` build mode: validator + both bldroot/prefix dispatch tables, with `dev` left byte-for-byte unchanged. `release` mirrors `dev` but injects a `release/` discriminator above suite/tag so its artifacts never mix with `dev`. The construction-time firewall keeps the user-facing `mode` choices in sync with what's implemented.
- `project.mode` is exported to the make subsystem (alongside `project.home`, `project.prefix`, …), riding the make command line so `$(project.mode)` is live from startup.
- Path-assembly refactor: `_devBldroot`/`_devPrefix` and the new `_releaseBldroot`/`_releasePrefix` share `_localBldroot`/`_localPrefix` helpers.

## `make/modes/` framework

- One file per implemented mode plus a `default` whose settings every mode inherits. `modes/init.mm` hard-`include`s `default.mm` then `$(project.mode).mm` — selecting a mode with no file is a **fatal** error (the make-layer echo of the driver firewall). Unset knobs *default to* the baseline (deliberate, distinct from silently failing).
- Recipes read named mode knobs grouped by consumer (e.g. `mode.npm.locked`), never the mode name.
- **Non-dev is the baseline**: `dev` is the one special mode (resolves fresh), and every deployment mode inherits the reproducible defaults — so new modes are usually near-empty and forgetting a knob fails safe.
- `mode.info` / `mode.help` pages, with `mode.info` advertised in the usage index.

## First consumers: `webpack` + `vite`

The npm dependency-install policy keyed on `mode.npm.locked`:

- **dev** → stage `package.json`, resolve fresh (`npm i`); the committed package lock file is ignored.
- **deployment modes** → stage `package.json` **and** the committed `package-lock.json`, install exactly (`npm ci`).
- **`<pack>.lock.seed`** — seed a clean `npm ci` from the committed lock regardless of mode; this is a recovery mechanism during `npm` instability and fails if the package lock lock file doesn't exist.
- **`<pack>.lock.harvest`** — harvest the package lock file as resolved by a successful build back to the source tree for committing, serving as a last-known-good resolution of the package dependencies.

The install prerequisite now is the `node_modules/` directory, not the staged configuration file, so a failed `npm` run always triggers a new attempt.

Verified against real assets (`qed.ux` for webpack; `examples/vite-relay`, `examples/vite-houdini` for vite) via the rule database and real builds: correct prerequisites and `npm i` vs `npm ci` per mode, the `node_modules` keying, and the seed/harvest targets all work; no undefined-variable warnings.