### PR TITLE
Stage an optional boot.main entry point as the bundle's __main__.py

### DIFF
--- a/etc/bash_completion/mm
+++ b/etc/bash_completion/mm
@@ -307,6 +307,7 @@ _comp_cmd_mm__get_target_description()
         *.assets)            echo "Build all assets" ;;
         *.schema.clean)      echo "Remove the generated schema" ;;
         *.boot)              echo "Assemble the bootstrap bundle (clean release)" ;;
+        *.boot.stage.*)      echo "(Re)stage a single bootstrap package" ;;
         *.boot.stage)        echo "Stage all bootstrap packages" ;;
         *.boot.bundle)       echo "Zip the staged bootstrap contents" ;;
         *.boot.clean)        echo "Discard the bootstrap release directory" ;;
@@ -652,6 +653,63 @@ _comp_cmd_mm__get_project_names()
     done
 }
 
+# Generate the per-package bootstrap staging targets for projects that opt in
+# with a non-empty {project}.boot.packages. Each package reference is resolved
+# to its stem, since the target is {project}.boot.stage.{stem}.
+# @param project_root  Path to the project root directory
+# @return List of {project}.boot.stage.{stem} targets (one per line)
+_comp_cmd_mm__get_boot_stage_targets()
+{
+    local project_root=$1
+    local mm_dir="$project_root/.mm"
+
+    [[ ! -d "$mm_dir" ]] && return
+
+    # Map every package reference to its declared stem
+    local -A stems
+    local ref stem
+    while IFS='|' read -r ref stem; do
+        [[ -z "$ref" || -z "$stem" ]] && continue
+        stems["$ref"]="$stem"
+    done < <(awk '
+        /\.stem[[:space:]]*:?=[[:space:]]/ {
+            ref = $0;
+            sub(/[[:space:]]*:?=.*$/, "", ref);
+            sub(/\.stem$/, "", ref);
+            sub(/^[[:space:]]*/, "", ref);
+            val = $0;
+            gsub(/#.*/, "", val);
+            sub(/^.*:?=[[:space:]]*/, "", val);
+            sub(/[[:space:]]+$/, "", val);
+            if (ref != "" && val != "") print ref "|" val;
+        }
+    ' "$mm_dir"/*.mm 2>/dev/null)
+
+    # For each declared boot.packages entry, emit {project}.boot.stage.{stem}
+    local project pkgref
+    while IFS='|' read -r project pkgref; do
+        [[ -z "$project" || -z "$pkgref" ]] && continue
+        # fall back to the reference itself if no explicit stem was found
+        echo "${project}.boot.stage.${stems[$pkgref]:-$pkgref}"
+    done < <(awk '
+        /\.boot\.packages[[:space:]]*:?=[[:space:]]/ {
+            proj = $0;
+            sub(/\.boot\.packages.*$/, "", proj);
+            sub(/^[[:space:]]*/, "", proj);
+            sub(/^[^:+]*:?=[[:space:]]*/, "");
+            gsub(/#.*/, "");
+            n = split($0, a);
+            for (i = 1; i <= n; i++) if (a[i] != "" && a[i] !~ /\\/) print proj "|" a[i];
+            while ($0 ~ /\\[[:space:]]*$/) {
+                if (getline <= 0) break;
+                gsub(/#.*/, "");
+                n = split($0, a);
+                for (i = 1; i <= n; i++) if (a[i] != "" && a[i] !~ /\\/) print proj "|" a[i];
+            }
+        }
+    ' "$mm_dir"/*.mm 2>/dev/null) | sort -u
+}
+
 # =============================================================================
 # Test target discovery (filesystem scan)
 # =============================================================================
@@ -991,6 +1049,13 @@ _comp_cmd_mm__get_all_targets()
                 targets="$targets ${proj}${suffix}"
             done
         done
+
+        # 3b. Per-package bootstrap staging targets ({project}.boot.stage.{stem})
+        local boot_stage_targets
+        boot_stage_targets=$(_comp_cmd_mm__get_boot_stage_targets "$project_root")
+        if [[ -n "$boot_stage_targets" ]]; then
+            targets="$targets $(echo "$boot_stage_targets" | tr '\n' ' ')"
+        fi
 
         # 4. Parse asset declarations and generate suffixed targets
         local assets

--- a/etc/zsh_completion/_mm
+++ b/etc/zsh_completion/_mm
@@ -601,6 +601,63 @@ _mm_complete_project_targets() {
     (( ${#specs} )) && _describe -t project-targets 'project target' specs
 }
 
+# Generate per-package bootstrap staging target completions
+# ({project}.boot.stage.{stem}) for projects that declare boot.packages; each
+# package reference is resolved to its stem, since that is what names the target
+_mm_complete_boot_stage_targets() {
+    local project_root
+    project_root="$(_mm_find_project_root)"
+    [[ -z "$project_root" ]] && return 1
+
+    local mm_dir="$project_root/.mm"
+    [[ ! -d "$mm_dir" ]] && return 1
+
+    # Map every package reference to its declared stem
+    typeset -A stems
+    local ref stem
+    while IFS='|' read -r ref stem; do
+        [[ -z "$ref" || -z "$stem" ]] && continue
+        stems[$ref]="$stem"
+    done < <(awk '
+        /\.stem[[:space:]]*:?=[[:space:]]/ {
+            ref = $0;
+            sub(/[[:space:]]*:?=.*$/, "", ref);
+            sub(/\.stem$/, "", ref);
+            sub(/^[[:space:]]*/, "", ref);
+            val = $0;
+            gsub(/#.*/, "", val);
+            sub(/^.*:?=[[:space:]]*/, "", val);
+            sub(/[[:space:]]+$/, "", val);
+            if (ref != "" && val != "") print ref "|" val;
+        }
+    ' "$mm_dir"/*.mm(N) 2>/dev/null)
+
+    local specs=()
+    local project pkgref
+    while IFS='|' read -r project pkgref; do
+        [[ -z "$project" || -z "$pkgref" ]] && continue
+        specs+=("${project}.boot.stage.${stems[$pkgref]:-$pkgref}:(Re)stage a single bootstrap package")
+    done < <(awk '
+        /\.boot\.packages[[:space:]]*:?=[[:space:]]/ {
+            proj = $0;
+            sub(/\.boot\.packages.*$/, "", proj);
+            sub(/^[[:space:]]*/, "", proj);
+            sub(/^[^:+]*:?=[[:space:]]*/, "");
+            gsub(/#.*/, "");
+            n = split($0, a);
+            for (i = 1; i <= n; i++) if (a[i] != "" && a[i] !~ /\\/) print proj "|" a[i];
+            while ($0 ~ /\\[[:space:]]*$/) {
+                if (getline <= 0) break;
+                gsub(/#.*/, "");
+                n = split($0, a);
+                for (i = 1; i <= n; i++) if (a[i] != "" && a[i] !~ /\\/) print proj "|" a[i];
+            }
+        }
+    ' "$mm_dir"/*.mm(N) 2>/dev/null)
+
+    (( ${#specs} )) && _describe -t boot-stage-targets 'boot stage target' specs
+}
+
 # Generate per-library target completions
 _mm_complete_library_targets() {
     local project_root
@@ -971,6 +1028,7 @@ mm-target-help() {
             *.assets)            echo "Build all assets" ;;
             *.schema.clean)      echo "Remove the generated schema" ;;
             *.boot)              echo "Assemble the bootstrap bundle (clean release)" ;;
+            *.boot.stage.*)      echo "(Re)stage a single bootstrap package" ;;
             *.boot.stage)        echo "Stage all bootstrap packages" ;;
             *.boot.bundle)       echo "Zip the staged bootstrap contents" ;;
             *.boot.clean)        echo "Discard the bootstrap release directory" ;;
@@ -1130,6 +1188,7 @@ _mm() {
             _alternative \
                 'global-targets:global target:_mm_complete_global_targets' \
                 'project-targets:project target:_mm_complete_project_targets' \
+                'boot-stage-targets:boot stage target:_mm_complete_boot_stage_targets' \
                 'library-targets:library target:_mm_complete_library_targets' \
                 'package-targets:package target:_mm_complete_package_targets' \
                 'extension-targets:extension target:_mm_complete_extension_targets' \

--- a/make/projects/init.mm
+++ b/make/projects/init.mm
@@ -58,6 +58,9 @@ define project.init =
     ${eval $(1).boot.contents ?= $($(1).boot.root)contents/}
     # the bundle archive itself
     ${eval $(1).boot.archive ?= $($(1).boot.root)$($(1).stem)-boot.zip}
+    # an optional entry-point script, staged as the archive's {__main__.py} so the bundle is
+    # directly runnable with {python bundle.zip}; empty unless the project provides one
+    ${eval $(1).boot.main ?=}
 
     # make
     # the directory from where {make} was invoked, i.e. the nearest parent with a local

--- a/make/projects/rules.mm
+++ b/make/projects/rules.mm
@@ -62,8 +62,12 @@ endef
 
 # zip the currently-staged contents into the archive, replacing any previous one
 #   usage: project.boot.zip {project}
+# when the project nominates an entry point, it is dropped in as {__main__.py} at the zip root
+# right before bundling, so the freshest copy always ships and {python bundle.zip} just works
 define project.boot.zip =
 	$(rm.force) $($(1).boot.archive)
+	$(mkdirp) $($(1).boot.contents)
+	${if $($(1).boot.main),${if $(wildcard $($(1).home)/$($(1).boot.main)),$(cp) $($(1).home)/$($(1).boot.main) $($(1).boot.contents)__main__.py}}
 	cd $($(1).boot.contents) && $(zip) $(zip.flags.bundle) $($(1).boot.archive) .
 	@${call log.asset,"boot",$($(1).boot.archive)}
 endef


### PR DESCRIPTION
## Stage an optional `boot.main` entry point, and complete its bundle targets

Generic `mm` machinery so a project's bootstrap bundle can ship a runnable `__main__.py`, plus shell
completion for the per-package bundle targets.

### `boot.main` staging rule

- `init.mm`: new opt-in variable `$(1).boot.main ?=` (empty by default), a path **relative to the
  project home**.
- `rules.mm` `project.boot.zip`: `mkdirp`s the bundle contents, then — when `boot.main` is set and
  the file exists — copies it to `contents/__main__.py` before zipping, so the freshest entry point
  always ships. The guard keeps an empty `boot.main` from ever matching the home directory.

A project opts in with e.g. `pyre.boot.main := etc/boot/main.py`. This is what makes
`python pyre-boot.zip` runnable (see **pyre/pyre#186**).

### Shell completion for `{project}.boot.stage.{stem}`

The existing completion already exposed the top-level boot targets (`.boot`, `.boot.stage`,
`.boot.bundle`, `.boot.clean`) but not the **per-package** restage targets
`{project}.boot.stage.{stem}`. Added them to both `etc/bash_completion/mm` and
`etc/zsh_completion/_mm`, matching the existing file-parsing approach (no subprocess): parse
`{project}.boot.packages` from the `.mm` config, resolve each package reference to its declared
`.stem`, and emit the target. Verified against pyre — resolves
`pyre.boot.packages := pyre.pkg journal.pkg merlin.pkg` to
`pyre.boot.stage.{pyre,journal,merlin}`. Both files pass `bash -n` / `zsh -n`.

### Commits

- `c3c9ed8` projects: stage an optional `boot.main` entry point as the bundle's `__main__.py`
- `4c7d778` etc/completions: bash completes `{project}.boot.stage.{stem}` targets
- `7ce9942` etc/completions: zsh completes `{project}.boot.stage.{stem}` targets
