### PR TITLE
conda: derive the python ABI suffix from the package manifest

### DIFF
--- a/make/extern/python/init.mm
+++ b/make/extern/python/init.mm
@@ -18,8 +18,9 @@ python.model ?= $(empty)
 python.interpreter ?= python$(python.version)$(python.model)
 # the configurator
 python.configurator ?= $(python.interpreter)-config
-# the interpreter tag, used to form pathnames
-python.tag ?= $(python.interpreter)$(python.model)
+# the interpreter tag, used to form pathnames; {interpreter} already carries the {model},
+# so appending it again would double the ABI suffix for free-threading and debug builds
+python.tag ?= $(python.interpreter)
 
 # compiler flags
 python.flags ?=

--- a/mm
+++ b/mm
@@ -1779,7 +1779,11 @@ class Builder(pyre.application, family="pyre.applications.mm", namespace="mm"):
                 "module": "pybind11",
             },
             "pyre": {"candidates": ["pyre"]},
-            "python": {"candidates": ["python"], "trim": True},
+            "python": {
+                "candidates": ["python"],
+                "handler": "_emitCondaPython",
+                "trim": True,
+            },
             "slepc": {"candidates": ["slepc"]},
             "sundials": {"candidates": ["sundials"]},
             "vtk": {"candidates": ["vtk"]},
@@ -1985,6 +1989,34 @@ class Builder(pyre.application, family="pyre.applications.mm", namespace="mm"):
         except ValueError:
             # record where it actually is
             entry["lines"].append(f"{target}.dir ?= {root}")
+
+    def _emitCondaPython(self, entry, recipe, candidate, record, prefix):
+        """
+        Emit the configuration for the python interpreter; conda ships free-threading builds
+        whose headers sit in {include/python3.14t}, so read the ABI suffix off the directory
+        that owns {Python.h} instead of rebuilding the name from the version alone
+        """
+        # the interpreter is installed at the root of the environment
+        entry["lines"].append("python.dir ?= $(conda.prefix)")
+        # find the directory that owns the main header
+        incdir = self._condaManifestDir(record, lambda path: path.name == "Python.h")
+        # if the manifest doesn't mention it, leave {model} at its {init.mm} default and let the
+        # {markers.headers} check downstream complain about the missing header
+        if incdir is None:
+            # nothing more we can say
+            return
+        # the stem that {init.mm} builds the interpreter name from, e.g. {python3.14}
+        stem = f"python{entry['version']}"
+        # whatever the directory appends to that stem is the ABI model: {t} for free-threading,
+        # {d} for a debug build, empty for the standard one
+        model = incdir.name[len(stem) :] if incdir.name.startswith(stem) else ""
+        # the standard build needs nothing; {init.mm} already defaults {model} to empty
+        if not model:
+            # so leave it alone
+            return
+        # otherwise hand the suffix to the build, so that the interpreter name, the configurator,
+        # the include path and the library name all pick it up together
+        entry["lines"].append(f"python.model ?= {model}")
 
     def _emitCondaCuda(self, index, prefix):
         """


### PR DESCRIPTION
## the symptom

`pyre`'s conda-forge CI (`pr-conda`, all eight legs) dies as soon as it reaches the first
pybind11 binding:

```
In file included from .../envs/pyre/lib/python3.14t/site-packages/pybind11/include/pybind11/detail/common.h:12,
                 ...
.../pybind11/include/pybind11/conduit/wrap_include_python_h.h:44:10: fatal error: Python.h: No such file or directory
```

The conda environment is active and healthy — `CONDA_PREFIX` is set, `mode=conda` resolves the
prefix, and the build lands in `.../build/pyre/opt-shared-linux-x86_64`. The problem is narrower
than that.

## the cause

Leaving `python` unpinned in an environment file lets the solver take the free-threading build,
because the `cp314t` build string outranks `cp314`:

```
+ python      3.14.6  hf9ea5aa_0_cp314t
+ python_abi  3.14    8_cp314t
```

Its headers live in `include/python3.14t`, not `include/python3.14`.

`_condaRecipes` trims python's version to `major.minor`, so the database gets
`python.version ?= 3.14`. `extern/python/init.mm` then *reconstructs* the path from that string:

```make
python.interpreter ?= python$(python.version)$(python.model)   # -> python3.14
python.incpath     ?= $(python.dir)/include/$(python.interpreter)
```

which points at a directory that does not exist. The ABI suffix is dropped on the floor.

The tell is in the error itself: pybind11's *own* headers resolve correctly, under
`lib/python3.14t/site-packages/...`, because `_emitCondaSitePackage` asks the module where it
lives on disk. Python's include directory is the one place we rebuild a path from a version
string rather than reading the manifest — and that is exactly where the `t` gets lost.

## the fix

Give `python` a `handler` that locates the directory owning `Python.h` in the package's
`conda-meta` record and reports whatever suffix that directory appends to `python{major.minor}`
as `python.model`. This is the same manifest-driven technique `_emitCondaCuda` already uses via
`commonRoot`, and that `_emitCondaSitePackage` uses for numpy and pybind11.

`init.mm` already has the right knob: `model` feeds `interpreter`, `configurator`, `incpath` and
`libraries` together, so one emitted line corrects all of them.

| | `model` | `interpreter` | `configurator` | `incpath` |
|---|---|---|---|---|
| free-threading | `t` | `python3.14t` | `python3.14t-config` | `.../include/python3.14t` |
| debug | `d` | `python3.13d` | `python3.13d-config` | `.../include/python3.13d` |
| standard | *(empty)* | `python3.14` | `python3.14-config` | `.../include/python3.14` |

Nothing is emitted for the standard build, so `init.mm`'s existing default stands and behaviour
there is bit-for-bit unchanged.

Note that `_condaResolve` skips the generic `{name}.dir ?= $(conda.prefix)` line once a recipe
names a handler, so `_emitCondaPython` emits it itself.

## the `python.tag` repair

`model` is the interpreter's *memory model* — historically the `m` of `python3.6m`, which
appeared in the include directory and the library name but not in the interpreter binary. Under
that design

```make
python.tag ?= $(python.interpreter)$(python.model)
```

was coherent: `interpreter` was the binary name, and `tag` was the decorated form used to build
pathnames.

The free-threading `t` pollutes the configuration differently. It appears in the binary name too,
so `python.interpreter` already carries it, and appending `model` a second time doubles the
suffix — `python3.14tt`. `tag` is consumed only by `extern.python.info`'s logging, so this is
cosmetic, but it becomes visible the moment `model` is non-empty. It is now
`python.tag ?= $(python.interpreter)`, identical to today's value whenever `model` is empty.

(An earlier revision of this description called the old form a latent bug that had "never been
observed because `model` has been empty everywhere until now." That was wrong: `model` was
non-empty throughout the `m` era, and the old arithmetic was correct then.)

## verification

- `_emitCondaPython` exercised against synthetic `conda-meta` records for the free-threading,
  debug, standard, and missing-`Python.h` cases.
- The `init.mm` expansion checked with `make` for both `model=t` and `model=`, confirming the
  standard build is unchanged.

