### PR TITLE
cosmetics: bring the preambles into conformance

### DIFF
--- a/examples/hello/.mm/hello.mm
+++ b/examples/hello/.mm/hello.mm
@@ -1,9 +1,8 @@
 # -*- Makefile -*-
 #
-# michael a.g. aïvázis
-# parasim
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
 # (c) 1998-2026 all rights reserved
-#
+
 
 # show me
 # ${info -- hello }

--- a/examples/hello/.mm/hello.questing-clang
+++ b/examples/hello/.mm/hello.questing-clang
@@ -1,4 +1,4 @@
-# -*- makefile -*-
+# -*- Makefile -*-
 #
 # michael a.g. aïvázis <michael.aivazis@para-sim.com>
 # (c) 1998-2026 all rights reserved

--- a/examples/hello/bin/say
+++ b/examples/hello/bin/say
@@ -3,9 +3,7 @@
 # -*- coding: utf-8 -*-
 #
 # michael a.g. aïvázis <michael.aivazis@para-sim.com>
-# parasim
 # (c) 1998-2026 all rights reserved
-#
 
 
 # get the package

--- a/examples/hello/etc/docker/questing-clang/prompt.py
+++ b/examples/hello/etc/docker/questing-clang/prompt.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # michael a.g. aïvázis <michael.aivazis@para-sim.com>
-# (c) 1998-2024 all rights reserved
+# (c) 1998-2026 all rights reserved
 
 
 # externals

--- a/examples/hello/pkg/hello/__init__.py
+++ b/examples/hello/pkg/hello/__init__.py
@@ -1,10 +1,8 @@
-# -*- Python-*-
+# -*- Python -*-
 # -*- coding: utf-8 -*-
 #
 # michael a.g. aïvázis <michael.aivazis@para-sim.com>
-# parasim
 # (c) 1998-2026 all rights reserved
-#
 
 
 # publish some pyre symbols

--- a/examples/hello/pkg/hello/cli/About.py
+++ b/examples/hello/pkg/hello/cli/About.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # michael a.g. aïvázis <michael.aivazis@para-sim.com>
-# parasim
 # (c) 1998-2026 all rights reserved
-#
 
 
 # my package

--- a/examples/hello/pkg/hello/cli/Complete.py
+++ b/examples/hello/pkg/hello/cli/Complete.py
@@ -1,9 +1,7 @@
 #-*- coding: utf-8 -*-
 #
 # michael a.g. aïvázis <michael.aivazis@para-sim.com>
-# parasim
 # (c) 1998-2026 all rights reserved
-#
 
 
 # support

--- a/examples/hello/pkg/hello/cli/Config.py
+++ b/examples/hello/pkg/hello/cli/Config.py
@@ -1,9 +1,7 @@
 #-*- coding: utf-8 -*-
 #
 # michael a.g. aïvázis <michael.aivazis@para-sim.com>
-# parasim
 # (c) 1998-2026 all rights reserved
-#
 
 
 # support

--- a/examples/hello/pkg/hello/cli/Goodbye.py
+++ b/examples/hello/pkg/hello/cli/Goodbye.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # michael a.g. aïvázis <michael.aivazis@para-sim.com>
-# parasim
 # (c) 1998-2026 all rights reserved
-#
 
 
 # my package

--- a/examples/hello/pkg/hello/cli/Greet.py
+++ b/examples/hello/pkg/hello/cli/Greet.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # michael a.g. aïvázis <michael.aivazis@para-sim.com>
-# parasim
 # (c) 1998-2026 all rights reserved
-#
 
 
 # the package

--- a/examples/hello/pkg/hello/cli/Hello.py
+++ b/examples/hello/pkg/hello/cli/Hello.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # michael a.g. aïvázis <michael.aivazis@para-sim.com>
-# parasim
 # (c) 1998-2026 all rights reserved
-#
 
 
 # my package

--- a/examples/hello/pkg/hello/cli/__init__.py
+++ b/examples/hello/pkg/hello/cli/__init__.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # michael a.g. aïvázis <michael.aivazis@para-sim.com>
-# parasim
 # (c) 1998-2026 all rights reserved
-#
 
 
 # pull in the command decorators

--- a/examples/hello/pkg/hello/ext/__init__.py
+++ b/examples/hello/pkg/hello/ext/__init__.py
@@ -1,10 +1,8 @@
-# -*- Python-*-
+# -*- Python -*-
 # -*- coding: utf-8 -*-
 #
 # michael a.g. aïvázis <michael.aivazis@para-sim.com>
-# parasim
 # (c) 1998-2026 all rights reserved
-#
 
 
 # pull the extension module

--- a/examples/hello/pkg/hello/meta.py.in
+++ b/examples/hello/pkg/hello/meta.py.in
@@ -2,9 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # michael a.g. aïvázis <michael.aivazis@para-sim.com>
-# parasim
 # (c) 1998-2026 all rights reserved
-#
 
 # expansion placeholders
 date = "@TODAY@"

--- a/examples/hello/pkg/hello/shells/Action.py
+++ b/examples/hello/pkg/hello/shells/Action.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # michael a.g. aïvázis <michael.aivazis@para-sim.com>
-# parasim
 # (c) 1998-2026 all rights reserved
-#
 
 
 # access the framework

--- a/examples/hello/pkg/hello/shells/Command.py
+++ b/examples/hello/pkg/hello/shells/Command.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # michael a.g. aïvázis <michael.aivazis@para-sim.com>
-# parasim
 # (c) 1998-2026 all rights reserved
-#
 
 
 # access the pyre framework

--- a/examples/hello/pkg/hello/shells/Plexus.py
+++ b/examples/hello/pkg/hello/shells/Plexus.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # michael a.g. aïvázis <michael.aivazis@para-sim.com>
-# parasim
 # (c) 1998-2026 all rights reserved
-#
 
 
 # externals

--- a/examples/hello/pkg/hello/shells/UX.py
+++ b/examples/hello/pkg/hello/shells/UX.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # michael a.g. aïvázis <michael.aivazis@para-sim.com>
-# parasim
 # (c) 1998-2026 all rights reserved
-#
 
 
 # external

--- a/examples/hello/pkg/hello/shells/__init__.py
+++ b/examples/hello/pkg/hello/shells/__init__.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # michael a.g. aïvázis <michael.aivazis@para-sim.com>
-# parasim
 # (c) 1998-2026 all rights reserved
-#
 
 
 # publish the local objects

--- a/examples/hello/tests/hello.pkg/sanity.py
+++ b/examples/hello/tests/hello.pkg/sanity.py
@@ -2,9 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # michael a.g. aïvázis <michael.aivazis@para-sim.com>
-# parasim
 # (c) 1998-2026 all rights reserved
-#
 
 
 """

--- a/examples/hello/tests/hello.pkg/say.py
+++ b/examples/hello/tests/hello.pkg/say.py
@@ -2,9 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # michael a.g. aïvázis <michael.aivazis@para-sim.com>
-# parasim
 # (c) 1998-2026 all rights reserved
-#
 
 
 """

--- a/examples/prep/.mm/prep.mm
+++ b/examples/prep/.mm/prep.mm
@@ -1,9 +1,8 @@
 # -*- Makefile -*-
 #
-# michael a.g. aïvázis
-# parasim
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
 # (c) 1998-2026 all rights reserved
-#
+
 
 # show me
 # ${info -- prep }

--- a/examples/simple/.mm/simple.ext
+++ b/examples/simple/.mm/simple.ext
@@ -1,4 +1,4 @@
-# -*- makefile -*-
+# -*- Makefile -*-
 #
 # michael a.g. aïvázis <michael.aivazis@para-sim.com>
 # (c) 1998-2026 all rights reserved

--- a/examples/simple/.mm/simple.lib
+++ b/examples/simple/.mm/simple.lib
@@ -1,4 +1,4 @@
-# -*- makefile -*-
+# -*- Makefile -*-
 #
 # michael a.g. aïvázis <michael.aivazis@para-sim.com>
 # (c) 1998-2026 all rights reserved

--- a/examples/simple/.mm/simple.lib.tests
+++ b/examples/simple/.mm/simple.lib.tests
@@ -1,4 +1,4 @@
-# -*- makefile -*-
+# -*- Makefile -*-
 #
 # michael a.g. aïvázis <michael.aivazis@para-sim.com>
 # (c) 1998-2026 all rights reserved

--- a/examples/simple/.mm/simple.pkg
+++ b/examples/simple/.mm/simple.pkg
@@ -1,4 +1,4 @@
-# -*- makefile -*-
+# -*- Makefile -*-
 #
 # michael a.g. aïvázis <michael.aivazis@para-sim.com>
 # (c) 1998-2026 all rights reserved

--- a/examples/simple/bin/simple
+++ b/examples/simple/bin/simple
@@ -1,5 +1,5 @@
 #! /usr/bin/env python3
-# -*- coding : utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # michael a.g.aïvázis <michael.aivazis@para-sim.com>
 # (c) 1998-2026 all rights reserved

--- a/examples/simple/pkg/simple/__init__.py
+++ b/examples/simple/pkg/simple/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding : utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # michael a.g.aïvázis <michael.aivazis@para-sim.com>
 # (c) 1998-2026 all rights reserved

--- a/examples/simple/pkg/simple/ext/__init__.py
+++ b/examples/simple/pkg/simple/ext/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding : utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # michael a.g.aïvázis <michael.aivazis@para-sim.com>
 # (c) 1998-2026 all rights reserved

--- a/make/compilers/gcc/gfortran.mm
+++ b/make/compilers/gcc/gfortran.mm
@@ -1,6 +1,6 @@
 # -*- Makefile -*-
 #
-# michael a.g. aïvázis <mmichael.aivazis@para-sim.com>
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
 # (c) 1998-2026 all rights reserved
 
 

--- a/make/compilers/intel/fortran.mm
+++ b/make/compilers/intel/fortran.mm
@@ -1,6 +1,6 @@
 # -*- Makefile -*-
 #
-# michael a.g. aïvázis <mmichael.aivazis@para-sim.com>
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
 # (c) 1998-2026 all rights reserved
 
 

--- a/make/extern/libtorch/init.mm
+++ b/make/extern/libtorch/init.mm
@@ -1,7 +1,7 @@
 # -*- Makefile -*-
 #
 # michael a.g. aïvázis <michael.aivazis@para-sim.com>
-# (c) 1998-2025 all rights reserved
+# (c) 1998-2026 all rights reserved
 
 # add to extern list unless already present
 extern += ${if ${filter libtorch,$(extern)},,libtorch}

--- a/make/extern/petsc/rules.mm
+++ b/make/extern/petsc/rules.mm
@@ -1,9 +1,8 @@
 # -*- Makefile -*-
 #
-# michael a.g. aïvázis
-# parasim
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
 # (c) 1998-2026 all rights reserved
-#
+
 
 # show me
 # ${info -- petsc.info}


### PR DESCRIPTION
Comment-only. No code, no build rules, no behaviour. Every hunk in this branch starts at line 8
or earlier of its file.

## why

Syncing `make/` against pyre's embedded copy (`share/mm/make/`) turned up four files that
differed *only* in their preamble. Pyre had already been through a cleanup pass; the standalone
engine never was. Fixing those exposed a further defect present in both copies, and then a
broader one across `examples/`.

## `make:` the engine

Four files, restoring byte-identity with `pyre`'s `share/mm/make/`:

- `compilers/gcc/gfortran.mm`, `compilers/intel/fortran.mm` — `mmichael.aivazis` → `michael.aivazis`
- `extern/libtorch/init.mm` — copyright still read `1998-2025`
- `extern/petsc/rules.mm` — the author line had lost its email

That last file then turned out to be non-conforming in *both* repositories: a stray `# parasim`
affiliation line and a bare `#` trailing the copyright, where the convention is a four-line
preamble followed by two blank lines. Corrected here and, identically, in
[pyre/pyre#189](https://github.com/pyre/pyre/pull/189).

`make/` and pyre's `share/mm/make/` now differ in exactly one file — `mm/rules.mm`, whose banner
deliberately reads `merlin mm` on the embedded side. The verbatim-copy invariant holds again.

## `examples:` the rest

The same `# parasim` + trailing `#` shape turned out to be endemic to `examples/hello`, and a
sweep of every tracked file surfaced a few more typos:

| defect | files |
|---|---|
| stray `# parasim` and the `#` trailing the copyright | 20 |
| `# -*- Python-*-` — mode line missing its space | 2 |
| `# -*- coding : utf-8 -*-` — stray space | 3 |
| `# -*- makefile -*-` — lowercase, against 69 `Makefile` elsewhere | 5 |
| `(c) 1998-2024` | 1 |

## what was deliberately left alone

`mm` (the driver) and `examples/simple/pkg/simple/meta.py.in` carry `# -*- python -*-` in
lowercase. Since the driver itself uses that form, it reads as a choice rather than a slip, so
neither was touched.

`examples/step08/etc/bash/activate.bash` and its `step09` twin have a `#` after the copyright
too, but there it separates the preamble from a descriptive comment block rather than trailing
it. An early pass stripped those; they were restored.

## verification

- Every hunk confirmed to start at line 8 or earlier — no file body was touched.
- Re-scanned for all six defect classes afterwards: clean.
- `make/` diffed against `pyre`'s `share/mm/make/`: one file differs, the intentional banner.