### PR TITLE
pkgdb: discover hdf5 and mpi variant subdirectories under dpkg

### DIFF
--- a/make/extern/hdf5/init.mm
+++ b/make/extern/hdf5/init.mm
@@ -10,10 +10,11 @@ extern += ${if ${filter hdf5,$(extern)},,hdf5}
 # find my configuration file
 hdf5.config := ${dir ${call extern.config,hdf5}}
 
-hdf5.parallel ?= off
-# {parallel} selects serial vs mpi-aware hdf5, so it must always carry a value; declare it required
+hdf5.parallel ?= serial
+# {parallel} names the build flavor: {serial} is a plain build, {openmpi}/{mpich} are mpi-aware and
+# induce the mpi dependency below; it must always carry a value, so declare it required
 hdf5.markers.required ?= parallel
-hdf5.markers.required.hint ?= "(hdf5.parallel must be 'on' or 'off')"
+hdf5.markers.required.hint ?= "(hdf5.parallel must be 'serial', 'openmpi', or 'mpich')"
 
 # compiler flags
 hdf5.flags ?=

--- a/mm
+++ b/mm
@@ -2477,11 +2477,38 @@ class Builder(pyre.application, family="pyre.applications.mm", namespace="mm"):
                     if pyVersion:
                         print(f"python.version ?= {pyVersion}", file=f)
                     print(f"python.dir ?= $(dpkg.prefix)", file=f)
-                # mpi needs its flavor to select the right library names
+                # mpi: debian/ubuntu tuck the flavor's headers and libraries under a
+                # {<multiarch>/<flavor>} subtree ({openmpi/include}, {openmpi/lib}) rather than the
+                # bare {dir}/include and {dir}/lib, so read the real locations from {dpkg -L}
                 elif name == "mpi":
-                    print(f"mpi.dir ?= $(dpkg.prefix)", file=f)
+                    # the flavor selects the library names downstream
                     flavor = "openmpi" if "openmpi" in candidate else "mpich"
                     print(f"mpi.flavor ?= {flavor}", file=f)
+                    # the files the dev package installed
+                    files = self._dpkgFiles(dpkg, candidate)
+                    # locate the C header — the one on an {include} path, not the fortran module —
+                    # and the runtime library's dev symlink
+                    header = next(
+                        (p for p in files if p.name == "mpi.h" and "/include/" in str(p)),
+                        None,
+                    )
+                    library = next(
+                        (p for p in files if p.name == "libmpi.so"), None
+                    )
+                    # point the include path at wherever {mpi.h} really lives
+                    if header:
+                        print(
+                            f"mpi.incpath ?= {self._dpkgAnchor(header.parent, prefix)}",
+                            file=f,
+                        )
+                    # and the library path at wherever the dev symlink really lives
+                    if library:
+                        print(
+                            f"mpi.libpath ?= {self._dpkgAnchor(library.parent, prefix)}",
+                            file=f,
+                        )
+                    # anchor the package root like everything else
+                    print(f"mpi.dir ?= $(dpkg.prefix)", file=f)
                 # numpy headers live under the python package directory
                 elif name == "numpy":
                     includePath = self._queryPythonExpression(
@@ -2512,6 +2539,38 @@ class Builder(pyre.application, family="pyre.applications.mm", namespace="mm"):
                             print(f"pybind11.dir ?= {pybind11Root}", file=f)
                     else:
                         print(f"pybind11.dir ?= $(dpkg.prefix)", file=f)
+                # hdf5: debian/ubuntu split the flavors into variant subdirectories — headers under
+                # {include/hdf5/<variant>} and libraries under {lib/<multiarch>/hdf5/<variant>} — so
+                # the bare {dir}/include and {dir}/lib defaults miss them; read the real locations
+                # from {dpkg -L}, which also reveals the variant and hence {hdf5.parallel}
+                elif name == "hdf5":
+                    # the files the dev package installed
+                    files = self._dpkgFiles(dpkg, candidate)
+                    # locate the umbrella header and the dev-symlink library
+                    header = next((path for path in files if path.name == "hdf5.h"), None)
+                    library = next(
+                        (path for path in files if path.name == "libhdf5.so"), None
+                    )
+                    # point the include path at wherever {hdf5.h} really lives
+                    if header:
+                        print(
+                            f"hdf5.incpath ?= {self._dpkgAnchor(header.parent, prefix)}",
+                            file=f,
+                        )
+                    # and the library path at wherever the dev symlink really lives
+                    if library:
+                        print(
+                            f"hdf5.libpath ?= {self._dpkgAnchor(library.parent, prefix)}",
+                            file=f,
+                        )
+                    # the enclosing directory name is the flavor and doubles as {hdf5.parallel}:
+                    # {serial} is a plain build; {openmpi}/{mpich} name mpi, so the {findstring mpi}
+                    # gate in hdf5/init.mm folds mpi into {hdf5.dependencies} for parallel builds
+                    variant = header.parent.name if header else "serial"
+                    # {hdf5.parallel} carries the flavor name so parallel builds induce the mpi edge
+                    print(f"hdf5.parallel ?= {variant}", file=f)
+                    # anchor the package root like everything else
+                    print(f"hdf5.dir ?= $(dpkg.prefix)", file=f)
                 # all other packages anchor to the dpkg prefix
                 else:
                     print(f"{name}.dir ?= $(dpkg.prefix)", file=f)


### PR DESCRIPTION
## Problem

On Debian/Ubuntu, hdf5 and openmpi tuck their headers and libraries into **variant subdirectories**
that `_buildDpkgPackageDatabase` did not probe:

- hdf5 (`libhdf5-dev`, serial): `hdf5.h` in `/usr/include/hdf5/serial/`, libs in
  `/usr/lib/<multiarch>/hdf5/serial/`
- openmpi (`libopenmpi-dev`): `mpi.h` in `/usr/lib/<multiarch>/openmpi/include/`, libs in
  `.../openmpi/lib/`

The emitter wrote only `<pkg>.dir`, so `hdf5.incpath` / `mpi.incpath` fell back to the bare
`$(dir)/include` (`/usr/include`) and the compiles failed with `hdf5.h`/`mpi.h` not found.

## Fix

Give hdf5 and mpi bespoke emitter branches (like python/numpy/pybind11) that read the real locations
from `dpkg -L`:

- hdf5: locate `hdf5.h` and `libhdf5.so`, emit `hdf5.incpath` / `hdf5.libpath` via `_dpkgAnchor`.
  Emit `hdf5.parallel` = the flavor (the header's enclosing dir: `serial` / `openmpi` / `mpich`) so
  the existing `findstring mpi` gate in `make/extern/hdf5/init.mm` folds `mpi` into
  `hdf5.dependencies` for parallel builds. The transitive edge stays owned by the make engine.
- mpi: locate `mpi.h` (the one on an `/include/` path, not the fortran module) and `libmpi.so`,
  emit `mpi.incpath` / `mpi.libpath`.

Also corrects the stale `hdf5.parallel` marker hint (was "on/off"; the value is really the flavor
`serial`/`openmpi`/`mpich`) and the default (`off` → `serial`).

## Verification

Builds pyre from scratch against apt packages in an `ubuntu:24.04` container; hdf5/mpi resolve and
the full test suite passes.

The embedded clone of this logic in pyre's `packages/merlin/shells/MM.py` gets the same fix in a
companion pyre PR.