### PR TITLE
pkgdb: discover libpq headers under the postgresql subdirectory

### DIFF
--- a/mm
+++ b/mm
@@ -2571,6 +2571,29 @@ class Builder(pyre.application, family="pyre.applications.mm", namespace="mm"):
                     print(f"hdf5.parallel ?= {variant}", file=f)
                     # anchor the package root like everything else
                     print(f"hdf5.dir ?= $(dpkg.prefix)", file=f)
+                # libpq: debian/ubuntu put the client headers in a {postgresql} subdirectory of
+                # {/usr/include} that the bare {dir}/include default misses, and the library in the
+                # multiarch lib dir; read both real locations from {dpkg -L}
+                elif name == "libpq":
+                    # the files the dev package installed
+                    files = self._dpkgFiles(dpkg, candidate)
+                    # locate the client header and the dev-symlink library
+                    header = next((p for p in files if p.name == "libpq-fe.h"), None)
+                    library = next((p for p in files if p.name == "libpq.so"), None)
+                    # point the include path at wherever {libpq-fe.h} really lives
+                    if header:
+                        print(
+                            f"libpq.incpath ?= {self._dpkgAnchor(header.parent, prefix)}",
+                            file=f,
+                        )
+                    # and the library path at wherever the dev symlink really lives
+                    if library:
+                        print(
+                            f"libpq.libpath ?= {self._dpkgAnchor(library.parent, prefix)}",
+                            file=f,
+                        )
+                    # anchor the package root like everything else
+                    print(f"libpq.dir ?= $(dpkg.prefix)", file=f)
                 # all other packages anchor to the dpkg prefix
                 else:
                     print(f"{name}.dir ?= $(dpkg.prefix)", file=f)


### PR DESCRIPTION
Third in the series after #49 (hdf5/mpi): another external whose dpkg discovery lands the header
outside the bare `$(dir)/include`.

## Problem

On Debian/Ubuntu `libpq-dev` installs the client header at `/usr/include/postgresql/libpq-fe.h`
and the library at `/usr/lib/<multiarch>/libpq.so`. `_buildDpkgPackageDatabase` had no `libpq`
branch, so it fell through to the generic `else` and emitted only `libpq.dir`, leaving
`libpq.incpath` at the default `/usr/include`. Building against libpq then fails with
`fatal error: 'libpq-fe.h' file not found`.

## Fix

A `libpq` emitter branch (same shape as hdf5/mpi): read `dpkg -L` for `libpq-fe.h` and `libpq.so`
and emit `libpq.incpath` / `libpq.libpath` via `_dpkgAnchor`.

## Verification

In an `ubuntu:24.04` container with `libpq-dev` installed, `mm extern.libpq.info` now reports
`incpath = /usr/include/postgresql`, `libpath = /usr/lib/aarch64-linux-gnu`, and pyre's
`pyre-postgres` binding sources compile against a live postgresql-16 server (they failed on the
missing header before).

The embedded clone in pyre's `packages/merlin/shells/MM.py` gets the same fix in a companion pyre PR.

Turned up while standing up a postgres server in the new pyre dev containers — a reminder the dpkg
sniffer wants a systematic per-package audit.