### PR TITLE
Code coverage support

### DIFF
--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -68,6 +68,22 @@ shared library and dozens of drivers — llvm-cov reports "functions have mismat
 and skips the conflicting instances. This is expected for a template-heavy suite and does
 not corrupt the totals; it is a mild undercount of the skipped functions.
 
+### Header attribution
+
+A test driver includes a library's headers from the install prefix, so without help the
+compiler records the *installed* copy's path in the coverage data. That makes gcov's
+reporter (rooted at the project) drop the headers, and makes llvm-cov attribute them to the
+prefix rather than to the tree you edit. A `cov` build corrects this at compile time: for
+each library, mm emits a `-fprofile-prefix-map` (gcc) / `-fcoverage-prefix-map` (clang) that
+rewrites the library's installed header directory back to its source directory. The maps are
+generated from the library model — one per library — and ordered general-to-specific so the
+compilers' last-match-wins rule attributes each header to the correct source tree.
+
+The contribution is wired through `compiler.option.sources` as a `coverage.<language>`
+party, added only when `cov` is among the target variants, so a non-coverage build is
+untouched. The effect is that header coverage lands on the actual source files, both back
+ends agree, and the lcov the editor reads points at the tree you have open.
+
 Two caveats worth keeping in front of you when reading a coverage number:
 
 - It measures **execution, not correctness**. A line that runs but computes the wrong
@@ -123,3 +139,7 @@ The lcov file is what the editor reads. Install the **Coverage Gutters** extensi
 `coverage.info` prints the exact lcov path for the active build. "Watch" then paints
 covered/uncovered lines in the gutter and inline. The extension is tool-agnostic — it
 neither knows nor cares that mm produced the file.
+
+Because header coverage is attributed back to source (see *Header attribution* above), the
+lcov points at the files in your working tree — libraries and their headers alike — so the
+gutters light up on the source you actually edit, not on installed copies under the prefix.

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -1,0 +1,117 @@
+# mm — Code Coverage
+
+Coverage is a `target` variant, `cov`, alongside `debug`, `opt`, `shared`. Adding it
+to the target list compiles and links the compiled languages with their coverage
+instrumentation, gives the build its own build-root and install-prefix (so a coverage
+build never mixes with a regular one), and enables a `coverage` target that gathers the
+data a test run produced and renders it three ways: a terminal summary, a browsable
+HTML tree, and an lcov file for the editor.
+
+```
+mm --target=cov,shared <suite>      # build + run the tests with instrumentation
+mm --target=cov,shared coverage     # merge the data and render the report
+```
+
+The two steps use the *same* `--target`, because the report lives under the coverage
+build-root and reads the binaries from the coverage prefix.
+
+---
+
+## Back ends
+
+The instrumentation and the reader are chosen from the c++ compiler, in
+`make/coverage/model.mm`:
+
+- **`llvm`** (the clang family). Compiles with `-fprofile-instr-generate
+  -fcoverage-mapping`. Each instrumented process writes its own `.profraw`; mm exports
+  `LLVM_PROFILE_FILE` for the whole build so every test driver deposits one into the
+  collection directory with no per-recipe plumbing. The report is produced by
+  `llvm-profdata merge` followed by `llvm-cov report` / `show` / `export`. This mode
+  records **regions and branches**, not just lines, and resolves templates correctly —
+  which is why it is preferred for the heavily-templated C++ in `pyre`.
+
+- **`gcov`** (gcc). Compiles with `--coverage`; the compiler drops `.gcno`/`.gcda`
+  sidecars next to the objects. The report is produced by `gcovr`, which discovers
+  those pairs beneath the project root and emits HTML and lcov in one pass.
+
+Both back ends converge on **lcov** as the interchange format, so everything
+downstream — the HTML renderers and the editor — speaks one language regardless of
+compiler.
+
+Fortran (`flang`) is switched to the llvm form to match the clang front ends, so a
+mixed C/C++/Fortran binary links against a single coverage runtime. `flang`'s coverage
+support trails clang's; if a build rejects the flags, fall back to `--coverage` in
+`make/compilers/clang/flang.mm` and read the Fortran with `gcov`/`gcovr`.
+
+---
+
+## What the report covers
+
+The llvm reporter attributes the profiles to a set of binaries. mm discovers every
+shared library installed under the prefix automatically. Code that lives **only** in a
+test driver — most importantly instantiated templates from a header-only library — is
+not in any `.so`, so the driver binary must be named explicitly:
+
+```makefile
+# in a project's .mm configuration
+coverage.objects += $(builder.staging)<path-to-compiled-test-driver>
+```
+
+This is the pyre case: the grid templates are instantiated into the drivers, so without
+adding the drivers the report only sees whatever the shared libraries instantiated.
+
+Two caveats worth keeping in front of you when reading a coverage number:
+
+- It measures **execution, not correctness**. A line that runs but computes the wrong
+  value reports as covered.
+- For header-only templates it only sees the **instantiations the tests happen to
+  create**. A high percentage measures those instantiations, not the API surface.
+
+Where it earns its keep: unreached error paths, unexercised branches, and rank-0/rank-1
+edge cases.
+
+---
+
+## Targets
+
+| target            | effect                                                        |
+|-------------------|---------------------------------------------------------------|
+| `coverage`        | merge the collected data and render summary + HTML + lcov     |
+| `coverage.info`   | show the resolved settings (back end, paths, active or not)   |
+| `coverage.clean`  | discard the collected data and the rendered report            |
+
+`coverage.clean` matters between measurement runs: the profiles accumulate, so wipe them
+before a fresh run to avoid folding a previous run's data into the new report.
+
+---
+
+## Tooling
+
+The reporters are not part of a compiler install and must be present on the `PATH`:
+
+- **llvm back end:** `llvm-profdata`, `llvm-cov` — conda-forge **`llvm-tools`**; Ubuntu
+  **`llvm`** (they ship with the LLVM distribution).
+- **gcov back end:** `gcovr` — conda-forge **`gcovr`**; Ubuntu **`gcovr`**. `gcov`
+  itself ships with `gcc`.
+
+Neither reporter is invoked unless you ask for the `coverage` target, and each fails
+with a one-line instruction if its tool is missing.
+
+---
+
+## Editor integration (VS Code)
+
+The lcov file is what the editor reads. Install the **Coverage Gutters** extension
+(`ryanluker.vscode-coverage-gutters`) and point it at the lcov file:
+
+```jsonc
+// .vscode/settings.json
+{
+  "coverage-gutters.coverageFileNames": ["lcov.info"],
+  "coverage-gutters.coverageBaseDir": "<coverage build-root>/coverage"
+}
+```
+
+`coverage.info` prints the exact lcov path for the active build. "Watch" then paints
+covered/uncovered lines in the gutter and inline. The extension is tool-agnostic — it
+neither knows nor cares that mm produced the file.

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -47,18 +47,26 @@ support trails clang's; if a build rejects the flags, fall back to `--coverage` 
 
 ## What the report covers
 
-The llvm reporter attributes the profiles to a set of binaries. mm discovers every
-shared library installed under the prefix automatically. Code that lives **only** in a
-test driver — most importantly instantiated templates from a header-only library — is
-not in any `.so`, so the driver binary must be named explicitly:
+The llvm reporter attributes the profiles to a set of binaries, discovered automatically
+in the model pass: every shared library installed under the prefix, plus every compiled
+test-driver binary registered by the test suites. The drivers matter because a header-only
+template library instantiates most of its code into them rather than into any `.so` — the
+pyre grid case, where a report built from the shared libraries alone would miss nearly
+everything. A `wildcard` keeps only the binaries a given run actually built, so a partial
+test run never hands the reporter a missing object.
+
+A project rarely needs to name binaries by hand, but `coverage.objects` remains as an
+escape hatch for anything mm cannot find on its own:
 
 ```makefile
 # in a project's .mm configuration
-coverage.objects += $(builder.staging)<path-to-compiled-test-driver>
+coverage.objects += $(builder.staging)<path-to-some-other-instrumented-binary>
 ```
 
-This is the pyre case: the grid templates are instantiated into the drivers, so without
-adding the drivers the report only sees whatever the shared libraries instantiated.
+When the same inline or template function is instantiated across many binaries — the
+shared library and dozens of drivers — llvm-cov reports "functions have mismatched data"
+and skips the conflicting instances. This is expected for a template-heavy suite and does
+not corrupt the totals; it is a mild undercount of the skipped functions.
 
 Two caveats worth keeping in front of you when reading a coverage number:
 

--- a/etc/bash_completion/mm
+++ b/etc/bash_completion/mm
@@ -11,7 +11,7 @@
 # make/extern/rules.mm, make/projects/model.mm, make/projects/rules.mm,
 # make/libraries/rules.mm, make/packages/rules.mm, make/extensions/rules.mm,
 # make/tests/rules.mm, make/docker-images/rules.mm, make/webpack/rules.mm,
-# make/vite/rules.mm, make/modes/rules.mm
+# make/vite/rules.mm, make/modes/rules.mm, make/coverage/rules.mm
 _comp_cmd_mm__global_targets="
 help
 mm.usage
@@ -60,6 +60,9 @@ docker-images.info
 webpack.info
 vite.info
 toolchains.info
+coverage
+coverage.info
+coverage.clean
 "
 
 # =============================================================================

--- a/etc/bash_completion/test-completion.sh
+++ b/etc/bash_completion/test-completion.sh
@@ -159,6 +159,7 @@ test_completion "Complete 'projects'" "mm projects" "projects"
 test_completion "Complete 'libraries'" "mm libraries" "libraries\\.info"
 test_completion "Complete 'packages'" "mm packages" "packages\\.info"
 test_completion "Complete 'extensions'" "mm extensions" "extensions\\.info"
+test_completion "Complete 'coverage'" "mm coverage" "coverage"
 
 # =============================================================================
 # Test 5: Options after target

--- a/etc/zsh_completion/_mm
+++ b/etc/zsh_completion/_mm
@@ -73,6 +73,9 @@ typeset -a _mm_global_target_specs=(
     'webpack.info:List known webpack bundles'
     'vite.info:List known vite bundles'
     'toolchains.info:List environment-level developer toolchains'
+    'coverage:Merge coverage data and render the report'
+    'coverage.info:Show coverage settings for the current build'
+    'coverage.clean:Discard collected coverage data and the report'
 )
 
 # =============================================================================
@@ -1024,6 +1027,9 @@ mm-target-help() {
             webpack.info)        echo "List known webpack bundles" ;;
             vite.info)           echo "List known vite bundles" ;;
             toolchains.info)     echo "List environment-level developer toolchains" ;;
+            coverage)            echo "Merge coverage data and render the report" ;;
+            coverage.info)       echo "Show coverage settings for the current build" ;;
+            coverage.clean)      echo "Discard collected coverage data and the report" ;;
             *.directories)       echo "Create required directories" ;;
             *.assets)            echo "Build all assets" ;;
             *.schema.clean)      echo "Remove the generated schema" ;;
@@ -1180,7 +1186,7 @@ _mm() {
                 'opt[Optimized build (-O3)]' \
                 'shared[Position-independent code (-fPIC)]' \
                 'prof[Profiling support (-pg)]' \
-                'cov[Coverage instrumentation (--coverage)]' \
+                'cov[Coverage instrumentation]' \
                 'reldeb[Release with debug info (-g -O)]' \
                 && ret=0
             ;;

--- a/etc/zsh_completion/test-completion.zsh
+++ b/etc/zsh_completion/test-completion.zsh
@@ -124,6 +124,7 @@ assert_contains "Has 'extern.db.clean' target" "${_mm_global_target_specs[*]}" "
 assert_contains "Has 'libraries.info' target" "${_mm_global_target_specs[*]}" "libraries.info:List known"
 assert_contains "Has 'packages.info' target" "${_mm_global_target_specs[*]}" "packages.info:List known"
 assert_contains "Has 'extensions.info' target" "${_mm_global_target_specs[*]}" "extensions.info:List known"
+assert_contains "Has 'coverage' target" "${_mm_global_target_specs[*]}" "coverage:Merge coverage"
 
 # =============================================================================
 # Test 2: Suffix spec tables
@@ -660,11 +661,11 @@ assert_line "Second of two packages" "$ASSETS" "package|edge.pkg2"
 # =============================================================================
 echo "\n${BLUE}Test 18: Global target count${NC}"
 
-# We expect exactly 47 global targets
-if (( ${#_mm_global_target_specs} == 47 )); then
-    pass "Exactly 47 global targets"
+# We expect exactly 50 global targets
+if (( ${#_mm_global_target_specs} == 50 )); then
+    pass "Exactly 50 global targets"
 else
-    fail "Expected 47 global targets, got ${#_mm_global_target_specs}"
+    fail "Expected 50 global targets, got ${#_mm_global_target_specs}"
 fi
 
 # =============================================================================

--- a/make/compilers/clang/clang++.mm
+++ b/make/compilers/clang/clang++.mm
@@ -41,6 +41,9 @@ clang++.opt := -O3
 # regions and branches rather than lines, and it resolves templates correctly. the same string is
 # valid at both compile and link time, so the single target variable serves both categories
 clang++.cov := -fprofile-instr-generate -fcoverage-mapping
+# the flag that rewrites a source path prefix in the coverage mapping; the coverage machinery uses it
+# to map installed header paths back to their source tree so the report attributes to editable files
+clang++.cov.prefixmap := -fcoverage-prefix-map
 clang++.prof := -pg
 clang++.shared := -fPIC
 # openmp support

--- a/make/compilers/clang/clang++.mm
+++ b/make/compilers/clang/clang++.mm
@@ -37,7 +37,10 @@ clang++.compile.isysroot := -isysroot
 clang++.debug := -g
 clang++.reldeb := -Og -fno-omit-frame-pointer
 clang++.opt := -O3
-clang++.cov := --coverage
+# llvm source based coverage; richer than the gcov compatible {--coverage} because it records
+# regions and branches rather than lines, and it resolves templates correctly. the same string is
+# valid at both compile and link time, so the single target variable serves both categories
+clang++.cov := -fprofile-instr-generate -fcoverage-mapping
 clang++.prof := -pg
 clang++.shared := -fPIC
 # openmp support

--- a/make/compilers/clang/clang.mm
+++ b/make/compilers/clang/clang.mm
@@ -31,7 +31,10 @@ clang.compile.isysroot := -isysroot
 clang.debug := -g
 clang.opt := -O3
 clang.reldeb := -Og -fno-omit-frame-pointer
-clang.cov := --coverage
+# llvm source based coverage; richer than the gcov compatible {--coverage} because it records
+# regions and branches rather than lines, and it resolves templates correctly. the same string is
+# valid at both compile and link time, so the single target variable serves both categories
+clang.cov := -fprofile-instr-generate -fcoverage-mapping
 clang.prof := -pg
 clang.shared := -fPIC
 # openmp support

--- a/make/compilers/clang/clang.mm
+++ b/make/compilers/clang/clang.mm
@@ -35,6 +35,9 @@ clang.reldeb := -Og -fno-omit-frame-pointer
 # regions and branches rather than lines, and it resolves templates correctly. the same string is
 # valid at both compile and link time, so the single target variable serves both categories
 clang.cov := -fprofile-instr-generate -fcoverage-mapping
+# the flag that rewrites a source path prefix in the coverage mapping; the coverage machinery uses it
+# to map installed header paths back to their source tree so the report attributes to editable files
+clang.cov.prefixmap := -fcoverage-prefix-map
 clang.prof := -pg
 clang.shared := -fPIC
 # openmp support

--- a/make/compilers/clang/flang.mm
+++ b/make/compilers/clang/flang.mm
@@ -38,6 +38,9 @@ flang.opt := -O3
 # VERIFY: flang's coverage support trails clang's; if a build rejects these, fall back to the gcov
 # compatible {--coverage} and read this suite's fortran with {gcov}/{gcovr} instead of {llvm-cov}
 flang.cov := -fprofile-instr-generate -fcoverage-mapping
+# the flag that rewrites a source path prefix in the coverage mapping; the coverage machinery uses it
+# to map installed header paths back to their source tree so the report attributes to editable files
+flang.cov.prefixmap := -fcoverage-prefix-map
 # VERIFY: gprof-style -pg has limited support in LLVM Fortran; may silently do nothing
 flang.prof := -pg
 flang.shared := -fPIC

--- a/make/compilers/clang/flang.mm
+++ b/make/compilers/clang/flang.mm
@@ -33,8 +33,11 @@ flang.debug := -g
 # VERIFY: gfortran uses -g -O; using -g -O2 here as a conservative LLVM-friendly choice
 flang.reldeb := -g -O2
 flang.opt := -O3
-# VERIFY: --coverage (LLVM style) vs -coverage (GCC style); flang-new likely uses --coverage
-flang.cov := --coverage
+# match the llvm source based coverage the {clang} front ends use, so a mixed c++/fortran binary
+# links against a single coverage runtime and its objects feed the same {llvm-profdata} merge.
+# VERIFY: flang's coverage support trails clang's; if a build rejects these, fall back to the gcov
+# compatible {--coverage} and read this suite's fortran with {gcov}/{gcovr} instead of {llvm-cov}
+flang.cov := -fprofile-instr-generate -fcoverage-mapping
 # VERIFY: gprof-style -pg has limited support in LLVM Fortran; may silently do nothing
 flang.prof := -pg
 flang.shared := -fPIC

--- a/make/compilers/gcc/g++.mm
+++ b/make/compilers/gcc/g++.mm
@@ -32,6 +32,9 @@ g++.debug := -g
 g++.reldeb := -g -O
 g++.opt := -O3
 g++.cov := --coverage
+# the flag that rewrites a source path prefix in the coverage notes; the coverage machinery uses it to
+# map installed header paths back to their source tree so the report attributes to editable files
+g++.cov.prefixmap := -fprofile-prefix-map
 g++.prof := -pg
 g++.shared := -fPIC
 # openmp support

--- a/make/compilers/gcc/g++.mm
+++ b/make/compilers/gcc/g++.mm
@@ -57,9 +57,10 @@ g++.link.ext = $(platform.c++.ext)
 # command line options
 g++.defines = MM_COMPILER_gcc
 
-# clean up temporaries left behind while compiling
+# clean up temporaries left behind while compiling: the dependency file, plus the gcov coverage
+# notes and data ({.gcno}/{.gcda}) a {cov} build drops beside the object
 #  usage: g++.clean {base-name}
-g++.clean = $(1).d
+g++.clean = $(1).d $(1).gcno $(1).gcda
 
 # dependency generation
 # g++ does this in one pass: the dependency file gets generated during the compilation phase so

--- a/make/compilers/gcc/gcc.mm
+++ b/make/compilers/gcc/gcc.mm
@@ -32,6 +32,9 @@ gcc.debug := -g
 gcc.reldeb := -g -O
 gcc.opt := -O3
 gcc.cov := --coverage
+# the flag that rewrites a source path prefix in the coverage notes; the coverage machinery uses it to
+# map installed header paths back to their source tree so the report attributes to editable files
+gcc.cov.prefixmap := -fprofile-prefix-map
 gcc.prof := -pg
 gcc.shared := -fPIC
 # openmp support

--- a/make/compilers/gcc/gcc.mm
+++ b/make/compilers/gcc/gcc.mm
@@ -53,9 +53,10 @@ gcc.link.ext = $(platform.c.ext)
 # command line options
 gcc.defines = MM_COMPILER_gcc
 
-# clean up temporaries left behind while compiling
+# clean up temporaries left behind while compiling: the dependency file, plus the gcov coverage
+# notes and data ({.gcno}/{.gcda}) a {cov} build drops beside the object
 #  usage: gcc.clean {base-name}
-gcc.clean = $(1).d
+gcc.clean = $(1).d $(1).gcno $(1).gcda
 
 # dependency generation
 # gcc does this in one pass: the dependency file gets generated during the compilation phase so

--- a/make/compilers/gcc/gfortran.mm
+++ b/make/compilers/gcc/gfortran.mm
@@ -31,6 +31,9 @@ gfortran.debug := -g
 gfortran.reldeb := -g -O
 gfortran.opt := -O3
 gfortran.cov := -coverage
+# the flag that rewrites a source path prefix in the coverage notes; the coverage machinery uses it to
+# map installed header paths back to their source tree so the report attributes to editable files
+gfortran.cov.prefixmap := -fprofile-prefix-map
 gfortran.prof := -pg
 gfortran.shared := -fPIC
 # openmp support

--- a/make/compilers/gcc/gfortran.mm
+++ b/make/compilers/gcc/gfortran.mm
@@ -62,5 +62,10 @@ gfortran.mixed.libraries += gfortran
 define gfortran.makedep =
 endef
 
+# clean up temporaries left behind while compiling: the gcov coverage notes and data
+# ({.gcno}/{.gcda}) a {cov} build drops beside the object; gfortran emits no dependency file
+#  usage: gfortran.clean {base-name}
+gfortran.clean = $(1).gcno $(1).gcda
+
 
 # end of file

--- a/make/compilers/init.mm
+++ b/make/compilers/init.mm
@@ -121,6 +121,7 @@ ${strip
     platform.$(1)
     $(compiler.$(1))
     $(target.variants:%=targets.%.$(1))
+    ${if ${filter cov,$(target.variants)},coverage.$(1)}
     $(developer:%=developers.%.$(1))
 }
 endef

--- a/make/compilers/init.mm
+++ b/make/compilers/init.mm
@@ -121,7 +121,7 @@ ${strip
     platform.$(1)
     $(compiler.$(1))
     $(target.variants:%=targets.%.$(1))
-    ${if ${filter cov,$(target.variants)},coverage.$(1)}
+    ${if ${and ${filter cov,$(target.variants)},$($(compiler.$(1)).cov)},coverage.$(1)}
     $(developer:%=developers.%.$(1))
 }
 endef

--- a/make/coverage/init.mm
+++ b/make/coverage/init.mm
@@ -18,9 +18,12 @@ coverage.info ?=
 # the merged, indexed profile the llvm reporters read; the single product of folding all the raw
 # per-run profiles together
 coverage.profdata ?=
-# extra instrumented binaries a project wants folded into the llvm report beyond the shared
-# libraries mm discovers automatically; a header-only template library should add its compiled test
-# drivers here, since the templates are instantiated into the drivers rather than into any {.so}
+# the compiled test-driver binaries the report attributes template instantiations to; discovered
+# automatically from the registered test suites in the model pass
+coverage.drivers ?=
+# extra instrumented binaries a project wants folded into the llvm report beyond the shared libraries
+# and the test drivers mm discovers automatically; an escape hatch for binaries mm cannot find on its
+# own, not the normal path
 coverage.objects ?=
 
 

--- a/make/coverage/init.mm
+++ b/make/coverage/init.mm
@@ -25,6 +25,9 @@ coverage.drivers ?=
 # and the test drivers mm discovers automatically; an escape hatch for binaries mm cannot find on its
 # own, not the normal path
 coverage.objects ?=
+# the {installed-header=source-header} pairs that map coverage paths back to the source tree, one per
+# library; computed from the library model in the model pass
+coverage.prefixmap ?=
 
 
 # end of file

--- a/make/coverage/init.mm
+++ b/make/coverage/init.mm
@@ -1,0 +1,27 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# whether a coverage build is in effect; set in the model pass once {target.variants} is final
+coverage.active ?=
+# the instrumentation back end: {llvm} for the clang family, {gcov} for gcc; resolved from the
+# c++ compiler in the model pass
+coverage.backend ?=
+# the directory that collects the raw per-run profile data and the rendered reports; anchored under
+# the staging area in the model pass, since these are derived products of a build, not shipped files
+coverage.raw ?=
+coverage.report ?=
+# the lcov interchange file the vscode {Coverage Gutters} extension and the html renderers consume
+coverage.info ?=
+# the merged, indexed profile the llvm reporters read; the single product of folding all the raw
+# per-run profiles together
+coverage.profdata ?=
+# extra instrumented binaries a project wants folded into the llvm report beyond the shared
+# libraries mm discovers automatically; a header-only template library should add its compiled test
+# drivers here, since the templates are instantiated into the drivers rather than into any {.so}
+coverage.objects ?=
+
+
+# end of file

--- a/make/coverage/model.mm
+++ b/make/coverage/model.mm
@@ -82,19 +82,34 @@ coverage.objargs = \
 coverage.prefixmap = ${sort ${foreach lib,$(libraries),$($(lib).incdir)=$($(lib).prefix)}}
 
 # expose the coverage contribution to the compiler option machinery as a per language party:
-# {compiler.option.sources} adds a {coverage.<language>} source, but only under a {cov} filter, so these
-# flags reach a compile if and only if {cov} is a selected target. each compiled language whose compiler
-# names a {cov.prefixmap} flag gets a {coverage.<language>.flags} that turns every map pair into that
-# flag. it is recursively expanded so the map is computed at each object's bake, and it is defined here --
-# before {projects} -- so it exists by the time the first workflow bakes. only the map lookup is deferred;
-# the language and its compiler's flag name are fixed now
+# {compiler.option.sources} adds a {coverage.<language>} source, but only when {cov} is selected and the
+# language's compiler instruments -- so these flags reach a compile if and only if the compiler actually
+# does coverage. a language participates only if its compiler names a non-trivial {cov} flag; an empty
+# {cov} means the compiler does not instrument, so it contributes nothing. for a participating language,
+# first initialize each option category to empty -- exactly as {target.init} does for its own party -- so
+# the option assembly, which queries every category, never expands an undefined
+# {coverage.<language>.<category>}. then, if the compiler also names a {cov.prefixmap} flag, fill in the
+# flags category with the map: recursively expanded so the map is computed at each object's bake, and
+# defined here -- before {projects} -- so it exists by the time the first workflow bakes. only the map
+# lookup is deferred; the language and its compiler's flag name are fixed now. {value} reads the compiler
+# slot and {origin} tests the prefix-map flag without expanding either, so a missing compiler or flag
+# trips no undefined-variable warning
 ${foreach \
     language, \
     $(languages.compiled), \
-    ${if $($(compiler.$(language)).cov.prefixmap), \
-        ${eval \
-            coverage.$(language).flags = \
-                $${foreach pair,$$(coverage.prefixmap),$($(compiler.$(language)).cov.prefixmap)=$$(pair)} \
+    ${if ${value compiler.$(language)}, \
+        ${if $($(compiler.$(language)).cov), \
+            ${foreach \
+                category, \
+                $(languages.$(language).categories), \
+                ${eval coverage.$(language).$(category) ?=} \
+            } \
+            ${if ${filter-out undefined,${origin $(compiler.$(language)).cov.prefixmap}}, \
+                ${eval \
+                    coverage.$(language).flags = \
+                        $${foreach pair,$$(coverage.prefixmap),$($(compiler.$(language)).cov.prefixmap)=$$(pair)} \
+                } \
+            } \
         } \
     } \
 }

--- a/make/coverage/model.mm
+++ b/make/coverage/model.mm
@@ -41,9 +41,29 @@ ${eval coverage: coverage.$(coverage.backend)}
 # the raw profiles the llvm reporter folds together; a recursively expanded {wildcard} so the glob
 # runs when the recipe fires, by which point the test run has deposited the files
 coverage.raws = ${wildcard $(coverage.raw)*.profraw}
+
+# the compiled test drivers, gathered from every registered suite. this matters because a header-only
+# template library instantiates most of its code into the drivers rather than into any shared library,
+# so a report built only from the installed {.so}s would not see it. the suite metadata is final by the
+# time this class loads -- it comes up after {projects} -- so an immediate {:=} walk is safe; only a
+# coverage build pays the traversal. each suite's {staging.targets} mixes compiled, staged, and
+# interpreted cases, so keep the ones flagged {compiled} and take their {base} binary
+coverage.drivers := \
+    ${if $(coverage.active), \
+        ${foreach suite,$(testsuites), \
+            ${foreach case,$($(suite).staging.targets), \
+                ${if $($(case).compiled),$($(case).base)} \
+            } \
+        } \
+    }
 # the instrumented binaries to attribute the profiles to: every shared library installed under the
-# prefix, plus whatever compiled drivers a project adds through {coverage.objects}
-coverage.binaries = ${wildcard $(builder.dest.lib)*.so $(builder.dest.lib)*.dylib} $(coverage.objects)
+# prefix, the compiled test drivers, and whatever extra objects a project names through
+# {coverage.objects}. the {wildcard} over the drivers keeps only those a given run actually built, so a
+# partial test run never hands llvm-cov a missing {-object}
+coverage.binaries = \
+    ${wildcard $(builder.dest.lib)*.so $(builder.dest.lib)*.dylib} \
+    ${wildcard $(coverage.drivers)} \
+    $(coverage.objects)
 # llvm-cov takes the first binary as a positional argument and every subsequent one behind its own
 # {-object} flag; assemble that argument vector once for the three reporters to share
 coverage.objargs = \

--- a/make/coverage/model.mm
+++ b/make/coverage/model.mm
@@ -44,11 +44,11 @@ coverage.raws = ${wildcard $(coverage.raw)*.profraw}
 
 # the compiled test drivers, gathered from every registered suite. this matters because a header-only
 # template library instantiates most of its code into the drivers rather than into any shared library,
-# so a report built only from the installed {.so}s would not see it. the suite metadata is final by the
-# time this class loads -- it comes up after {projects} -- so an immediate {:=} walk is safe; only a
-# coverage build pays the traversal. each suite's {staging.targets} mixes compiled, staged, and
+# so a report built only from the installed {.so}s would not see it. recursively expanded so the walk
+# runs when a reporter fires: this class loads before {projects}, so the suite metadata is not yet final
+# here and a deferred read is required. each suite's {staging.targets} mixes compiled, staged, and
 # interpreted cases, so keep the ones flagged {compiled} and take their {base} binary
-coverage.drivers := \
+coverage.drivers = \
     ${if $(coverage.active), \
         ${foreach suite,$(testsuites), \
             ${foreach case,$($(suite).staging.targets), \
@@ -69,6 +69,35 @@ coverage.binaries = \
 coverage.objargs = \
     ${firstword $(coverage.binaries)} \
     ${patsubst %,-object %,${wordlist 2,${words $(coverage.binaries)},$(coverage.binaries)}}
+
+# rewrite installed header paths back to source. a test driver includes its project's headers from the
+# install prefix, so the coverage data records the installed copy's path; that makes gcov's reporter --
+# rooted at the project -- drop the headers, and makes the llvm reporter attribute them to the prefix
+# rather than to the tree the developer edits. for each library, map its installed header directory back
+# to the source directory the headers were copied from; both are already known to the library model. the
+# {sort} keys on the {incdir} left-hand side, and because a parent directory string sorts before any
+# child of it, this yields the general-to-specific order the compilers' last-match-wins mapping requires.
+# recursively expanded so it is evaluated where it is consumed -- in each object's compile options during
+# the projects pass -- by which point the libraries that object depends on have registered
+coverage.prefixmap = ${sort ${foreach lib,$(libraries),$($(lib).incdir)=$($(lib).prefix)}}
+
+# expose the coverage contribution to the compiler option machinery as a per language party:
+# {compiler.option.sources} adds a {coverage.<language>} source, but only under a {cov} filter, so these
+# flags reach a compile if and only if {cov} is a selected target. each compiled language whose compiler
+# names a {cov.prefixmap} flag gets a {coverage.<language>.flags} that turns every map pair into that
+# flag. it is recursively expanded so the map is computed at each object's bake, and it is defined here --
+# before {projects} -- so it exists by the time the first workflow bakes. only the map lookup is deferred;
+# the language and its compiler's flag name are fixed now
+${foreach \
+    language, \
+    $(languages.compiled), \
+    ${if $($(compiler.$(language)).cov.prefixmap), \
+        ${eval \
+            coverage.$(language).flags = \
+                $${foreach pair,$$(coverage.prefixmap),$($(compiler.$(language)).cov.prefixmap)=$$(pair)} \
+        } \
+    } \
+}
 
 
 # end of file

--- a/make/coverage/model.mm
+++ b/make/coverage/model.mm
@@ -1,0 +1,54 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# a coverage build is one whose variants include {cov}; the target machinery has already folded the
+# {cov} compile and link flags in by this point, so all that is left is to arrange the post-run
+# reporting
+coverage.active := ${filter cov,$(target.variants)}
+
+# pick the instrumentation back end from the c++ compiler: the clang family emits llvm source based
+# coverage that {llvm-profdata}/{llvm-cov} consume, while gcc emits gcov data that {gcovr} reads
+coverage.backend := ${if ${filter clang%,$(compiler.c++)},llvm,gcov}
+
+# anchor the derived products under the staging area, in a sibling of the build tree so a
+# {coverage.clean} can wipe them without touching object files
+coverage.raw := $(builder.staging)coverage/raw/
+coverage.report := $(builder.staging)coverage/report/
+# the lcov file lands at the root of the coverage area, at a stable path the editor can watch
+coverage.info := $(builder.staging)coverage/lcov.info
+# the merged profile the llvm reporters index against
+coverage.profdata := $(builder.staging)coverage/merged.profdata
+
+# when the llvm back end is active, steer every instrumented process launched during the build --
+# most importantly the test drivers -- to write its own raw profile into the collection directory.
+# {%p} keys the file by pid and {%m} by the binary's coverage signature, so concurrent drivers and
+# distinct binaries never clobber one another; the runtime creates the directory tree on first
+# write. exporting it here, once, spares every test recipe from having to thread it through by hand
+ifneq ($(strip $(coverage.active)),)
+ifeq ($(coverage.backend),llvm)
+export LLVM_PROFILE_FILE := $(coverage.raw)%p-%m.profraw
+endif
+endif
+
+# tie the top level {coverage} target to the back end specific reporter now that {coverage.backend} is
+# final; the report recipes themselves live in the rules pass, following mm's split of rule templates
+# in {rules.mm} from their instantiation here
+${eval coverage: coverage.$(coverage.backend)}
+
+# the raw profiles the llvm reporter folds together; a recursively expanded {wildcard} so the glob
+# runs when the recipe fires, by which point the test run has deposited the files
+coverage.raws = ${wildcard $(coverage.raw)*.profraw}
+# the instrumented binaries to attribute the profiles to: every shared library installed under the
+# prefix, plus whatever compiled drivers a project adds through {coverage.objects}
+coverage.binaries = ${wildcard $(builder.dest.lib)*.so $(builder.dest.lib)*.dylib} $(coverage.objects)
+# llvm-cov takes the first binary as a positional argument and every subsequent one behind its own
+# {-object} flag; assemble that argument vector once for the three reporters to share
+coverage.objargs = \
+    ${firstword $(coverage.binaries)} \
+    ${patsubst %,-object %,${wordlist 2,${words $(coverage.binaries)},$(coverage.binaries)}}
+
+
+# end of file

--- a/make/coverage/rules.mm
+++ b/make/coverage/rules.mm
@@ -1,0 +1,73 @@
+# -*- Makefile -*-
+#
+# michael a.g. aïvázis <michael.aivazis@para-sim.com>
+# (c) 1998-2026 all rights reserved
+
+
+# the coverage registry summary
+coverage.info-target:
+	@${call log.sec,"coverage","code coverage reporting for a {cov} build"}
+	@${call log.var,"active",${if $(coverage.active),"yes","no -- add 'cov' to the target variants"}}
+	@${call log.var,"backend","$(coverage.backend)"}
+	@${call log.var,"raw data","$(coverage.raw)"}
+	@${call log.var,"report","$(coverage.report)"}
+	@${call log.var,"lcov","$(coverage.info)"}
+	@${call log.sec,"  actions",}
+	@${call log.help,"coverage","merge the collected data and render the report"}
+	@${call log.help,"coverage.clean","discard the collected data and the rendered report"}
+	@${call log.help,"coverage.info","show these settings"}
+
+# the user facing info alias, matching the {<thing>.info} convention of the other registries
+coverage.info: coverage.info-target
+
+
+# the report generator dispatches on the instrumentation back end; the {coverage} target that ties it
+# to the resolved back end is emitted from the model pass, where {coverage.backend} is final. each
+# recipe first refuses to run outside a {cov} build, since without the instrumentation there is no
+# data to gather and the tools would only emit confusing errors
+
+# the llvm back end: fold the per-run raw profiles into one indexed profile, then read it against the
+# instrumented binaries to produce a terminal summary, a browsable html tree, and an lcov file for
+# the editor. the shared libraries are discovered under the install tree; a header-only template
+# library adds its compiled drivers through {coverage.objects}, since its code lives only there
+coverage.llvm:
+	@${if $(coverage.active),,${call log.error,"not a coverage build; add cov to the target variants and rerun"}; exit 1}
+	@command -v llvm-profdata >/dev/null 2>&1 || { ${call log.error,"'llvm-profdata' not found on the PATH"}; ${call log.info,"it ships with the llvm toolchain; see the coverage notes for the package name"}; exit 1; }
+	@${if $(strip $(coverage.raws)),,${call log.error,"no profile data under $(coverage.raw); build and run the tests under the same coverage target first"}; exit 1}
+	@${if $(strip $(coverage.binaries)),,${call log.error,"found no instrumented binaries; add compiled drivers or libraries through 'coverage.objects'"}; exit 1}
+	@${call log.action,"merge","$(coverage.profdata)"}
+	@$(mkdirp) ${dir $(coverage.profdata)}
+	@llvm-profdata merge -sparse $(coverage.raws) -o $(coverage.profdata)
+	@${call log.action,"report","coverage summary"}
+	@llvm-cov report -instr-profile=$(coverage.profdata) $(coverage.objargs)
+	@${call log.action,"html","$(coverage.report)"}
+	@llvm-cov show -instr-profile=$(coverage.profdata) -format=html -output-dir=$(coverage.report) $(coverage.objargs)
+	@${call log.action,"lcov","$(coverage.info)"}
+	@llvm-cov export -instr-profile=$(coverage.profdata) -format=lcov $(coverage.objargs) > $(coverage.info)
+
+# the gcov back end: {gcovr} discovers the {.gcno}/{.gcda} pairs beneath the project root and renders
+# both an html tree and an lcov file in one pass, keeping the two back ends interchangeable downstream
+coverage.gcov:
+	@${if $(coverage.active),,${call log.error,"not a coverage build; add cov to the target variants and rerun"}; exit 1}
+	@command -v gcovr >/dev/null 2>&1 || ( \
+	    ${call log.error,"'gcovr' not found on the PATH"}; \
+	    ${call log.info,"see the coverage notes for the package name"}; \
+	    exit 1 )
+	@$(mkdirp) $(coverage.report)
+	@${call log.action,"report","coverage summary"}
+	@gcovr --root $(project.home) --print-summary \
+	    --html-details $(coverage.report)index.html \
+	    --lcov $(coverage.info) \
+	    $(project.home)
+
+# discard the collected data and the rendered report, leaving the instrumented objects in place so a
+# fresh measurement run does not force a rebuild
+coverage.clean:
+	@${call log.action,"rm","$(builder.staging)coverage"}
+	@$(rm.force-recurse) $(builder.staging)coverage
+
+# these are phony bookkeeping targets, never files
+.PHONY: coverage coverage.llvm coverage.gcov coverage.clean coverage.info coverage.info-target
+
+
+# end of file

--- a/make/coverage/rules.mm
+++ b/make/coverage/rules.mm
@@ -45,8 +45,10 @@ coverage.llvm:
 	@${call log.action,"lcov","$(coverage.info)"}
 	@llvm-cov export -instr-profile=$(coverage.profdata) -format=lcov $(coverage.objargs) > $(coverage.info)
 
-# the gcov back end: {gcovr} discovers the {.gcno}/{.gcda} pairs beneath the project root and renders
-# both an html tree and an lcov file in one pass, keeping the two back ends interchangeable downstream
+# the gcov back end: {gcovr} discovers the {.gcno}/{.gcda} pairs and renders both an html tree and an
+# lcov file in one pass, keeping the two back ends interchangeable downstream. it searches two roots
+# because the coverage data is split: a test driver's data lands next to its in-tree source under the
+# project home, while a library object's data lands next to the object in the staging tree
 coverage.gcov:
 	@${if $(coverage.active),,${call log.error,"not a coverage build; add cov to the target variants and rerun"}; exit 1}
 	@command -v gcovr >/dev/null 2>&1 || ( \
@@ -58,7 +60,7 @@ coverage.gcov:
 	@gcovr --root $(project.home) --print-summary \
 	    --html-details $(coverage.report)index.html \
 	    --lcov $(coverage.info) \
-	    $(project.home)
+	    $(project.home) $(builder.staging)
 
 # discard the collected data and the rendered report, leaving the instrumented objects in place so a
 # fresh measurement run does not force a rebuild

--- a/make/merlin.mm
+++ b/make/merlin.mm
@@ -22,7 +22,7 @@ define model :=
     log mm modes
     languages platforms hosts users developers
     compilers targets builder runners toolchains
-	extern projects
+	extern projects coverage
 endef
 
 # the categories of methods each object provides

--- a/make/merlin.mm
+++ b/make/merlin.mm
@@ -22,7 +22,7 @@ define model :=
     log mm modes
     languages platforms hosts users developers
     compilers targets builder runners toolchains
-	extern projects coverage
+	extern coverage projects
 endef
 
 # the categories of methods each object provides


### PR DESCRIPTION
## Summary

Adds code coverage to mm as a build variant. Adding `cov` to the target list instruments the
compiled languages, gives the build its own build-root and install-prefix so it never mixes with
a regular build, and enables a `coverage` target that gathers the data a test run produced and
renders it as a terminal summary, a browsable HTML tree, and an lcov file.

```
mm --target=cov,shared <suite>      # build and run the tests with instrumentation
mm --target=cov,shared coverage     # merge the data and render the report
```

Both steps take the same `--target`, because the report lives under the coverage build-root and
reads the binaries from the coverage prefix.

## Back ends

The instrumentation and the reader are chosen from the C++ compiler.

The clang family uses LLVM source-based coverage: `-fprofile-instr-generate -fcoverage-mapping` at
compile and link. This records regions and branches rather than lines and resolves templates
correctly, which matters for heavily-templated C++. Each instrumented process writes its own
`.profraw`; mm exports `LLVM_PROFILE_FILE` once for the whole build, so every test driver deposits
a raw profile into the collection directory with no per-recipe plumbing. The report is produced by
`llvm-profdata merge` followed by `llvm-cov report` / `show` / `export`.

gcc uses `--coverage`, which drops `.gcno`/`.gcda` sidecars next to the objects; the report is
produced by `gcovr`, which discovers those pairs and emits HTML and lcov in one pass. Because a
library object's data lands in the staging tree while a driver's lands next to its in-tree source,
gcovr searches both roots.

Both back ends converge on lcov as the interchange format, so the HTML renderers and editors
downstream speak one language regardless of compiler. `flang` is switched to the LLVM form to match
the clang front ends; a fallback note records the gcov alternative if a build rejects the flags.

## Report scope

The reporters are pointed at the code under test automatically, discovered in the model pass: every
shared library installed under the prefix, plus every compiled test-driver binary registered by the
test suites. The drivers matter because a header-only template library instantiates most of its code
into them rather than into any `.so` — the pyre case, where a report built from the shared libraries
alone would miss nearly everything it tests. `coverage.objects` remains as an escape hatch for
anything mm cannot find on its own.

When the same inline or template function is instantiated across many binaries, llvm-cov reports
"functions have mismatched data" and skips the conflicting instances. This is expected for a
template-heavy suite and does not corrupt the totals; it is a mild undercount of the skipped
functions.

## Header attribution

A test driver includes a library's headers from the install prefix, so without help the compiler
records the *installed* copy's path in the coverage data. That makes gcov's reporter (rooted at the
project) drop the headers, and makes llvm-cov attribute them to the prefix rather than to the tree
you edit. A `cov` build corrects this at compile time: for each library, mm emits a
`-fprofile-prefix-map` (gcc) / `-fcoverage-prefix-map` (clang) that rewrites the library's installed
header directory back to its source directory. The maps come straight from the library model — one
per library — and are ordered general-to-specific so the compilers' last-match-wins rule attributes
each header to the correct source tree.

The contribution is wired through `compiler.option.sources` as a `coverage.<language>` party, added
only when `cov` is a selected target *and* the language's compiler instruments (its `cov` flag is
non-trivial), so a non-coverage build — and any language that does not do coverage — is untouched.
The effect is that header coverage lands on the actual source files, both back ends agree, and the
lcov the editor reads points at the tree you have open.

## Changes

- `make/compilers/clang/{clang,clang++,flang}.mm`, `make/compilers/gcc/{gcc,g++,gfortran}.mm` — the
  `cov` flag for the clang toolchain becomes the LLVM source-based form (gcc keeps `--coverage`), and
  each compiler names its per-compiler coverage prefix-map flag (`-fcoverage-prefix-map` /
  `-fprofile-prefix-map`). The gcc-family clean now also sweeps the `.gcno`/`.gcda` sidecars a `cov`
  build drops beside an object.
- `make/coverage/{init,model,rules}.mm` — a new model class, registered in `make/merlin.mm` ahead of
  `projects` so its option-source contributions exist before the workflows bake. `model.mm` resolves
  the back end, exports `LLVM_PROFILE_FILE`, discovers the profiles / shared libraries / test drivers,
  builds the per-library header prefix-map, and defines the `coverage.<language>` option party.
  `rules.mm` carries the report, info, and clean recipes. Each reporter refuses to run outside a `cov`
  build and fails with a one-line instruction when its tool is absent.
- `make/compilers/init.mm` — `compiler.option.sources` adds the `coverage.<language>` party under a
  `cov`-and-instruments guard.
- `etc/bash_completion/*`, `etc/zsh_completion/*` — the three new global targets (`coverage`,
  `coverage.info`, `coverage.clean`) registered in both completions, with the test suites updated.
- `docs/coverage.md` — usage, back ends, report scope, header attribution, targets, tools, and editor
  integration.

## Targets

| target           | effect                                                    |
|------------------|-----------------------------------------------------------|
| `coverage`       | merge the collected data and render summary + HTML + lcov |
| `coverage.info`  | show the resolved settings and the report paths           |
| `coverage.clean` | discard the collected data and the rendered report        |

`coverage.clean` matters between measurement runs: the profiles accumulate, so a fresh run should
start from a clean slate.

## Tools

The reporters are not part of a compiler install and must be on the `PATH`; they are invoked only
when the `coverage` target runs.

- llvm back end: `llvm-profdata`, `llvm-cov` — conda-forge `llvm-tools`; Ubuntu `llvm`.
- gcov back end: `gcovr` — conda-forge `gcovr`; Ubuntu `gcovr`. `gcov` ships with `gcc`.

For editors, the lcov drives VS Code's Coverage Gutters (`ryanluker.vscode-coverage-gutters`);
`coverage.info` prints its path. Because header coverage is attributed to source, the gutters light
up on the files in your working tree, not on installed copies under the prefix.

## Verification

Exercised end to end on a full `pyre.lib` build and test run — a heavily header-only, template-driven
library — across both back ends and both platforms:

- **clang / llvm** (macOS arm64 and Linux x64): report attributes every record to source, zero prefix
  leakage; header-only code (`lib/pyre/grid`, `lib/journal`, …) present.
- **gcc / gcov** (Linux x64): same — library and header coverage attributed to source, zero prefix
  leakage; driver auto-discovery and the staging-tree search recover the full surface.
- Driver auto-discovery takes the report from library-only visibility to the full template surface
  (functions counted roughly triple on pyre.lib once the drivers are included).
- A normal build is unaffected: coverage is inactive, no option party is added, and the
  `(clang, gcc) × (cov, no-cov)` matrix produces zero undefined-variable warnings.
- The bash and zsh completion suites pass.

## Notes on measurement

Coverage records execution, not correctness: a line that runs but computes the wrong value reports as
covered. For header-only templates it sees only the instantiations the tests create, so a percentage
measures those instantiations rather than the full API surface. It earns its keep on unreached error
paths, unexercised branches, and rank edge cases.
