### PR TITLE
make/modes: assert/DEBUG as a dev/release mode disposition

### DIFF
--- a/docs/modes.md
+++ b/docs/modes.md
@@ -91,6 +91,65 @@ so a missing install always re-runs. Two operator-facing targets round it out:
 This consumer only *queries a knob*; it does not change the shape of the build. The
 next part is about the cases that do.
 
+### Second consumer — the assert / developer-check disposition
+
+Whether a build compiles in its developer-time checks — the `assert`s, the code under
+`#if defined(DEBUG)`, and `journal`'s `debug`/`firewall` channels — is a **mode**
+disposition, not an optimization-target one. An optimized developer build should still
+check its invariants; a release build should drop them regardless of optimization
+level. The knob is `mode.compiler.assertions` (baseline empty, set to `yes` in `dev`).
+
+Two independent preprocessor macros govern this in C/C++ (and, harmlessly, any
+cpp-run Fortran):
+
+- **`DEBUG`** — our own convention, the gate for developer-only code (`#if
+  defined(DEBUG)`).
+- **`NDEBUG`** — the standard `<cassert>` guard: when defined, `assert()` becomes a
+  no-op.
+
+They are independent, so all four combinations are reachable, and two of them are
+incoherent:
+
+| `DEBUG` | `NDEBUG` | `#if defined(DEBUG)` | bare `assert()` | disposition        |
+|---------|----------|----------------------|-----------------|--------------------|
+| on      | off      | compiled             | live            | coherent — dev     |
+| off     | on       | skipped              | no-op           | coherent — release |
+| on      | on       | compiled             | **no-op**       | incoherent         |
+| off     | off      | skipped              | **live**        | incoherent         |
+
+mm takes ownership of the pair and keeps it coherent: **exactly one of the two is
+defined at all times**, so client code can never land in an incoherent row. The
+single point of ownership is `make/modes/init.mm`:
+
+```makefile
+mode.compiler.defines := ${if $(mode.compiler.assertions),DEBUG,NDEBUG}
+```
+
+- **dev** → `-DDEBUG`, no `NDEBUG`: developer code compiles in, `assert()` is live,
+  `journal` `debug`/`firewall` channels are real.
+- **release / conda / macports / ubuntu** → `-DNDEBUG`, no `DEBUG`: developer code is
+  gone, `assert()` is a no-op, the `journal` developer channels resolve to `null_t`.
+
+The value rides in through a flat, language-independent option source `mode.compiler`
+(the same shape as `mm`) added to `compiler.option.sources`; like `mm`, it declares
+its full category set so no slot is ever an undefined variable. This is orthogonal to
+`target`: `--target=opt` under the default `dev` mode keeps asserts **live** (the
+optimized-but-checked build); `--target=debug --mode=release` gives debug symbols with
+asserts **off**.
+
+Guidance for client code under this convention:
+
+- Prefer a **bare `assert()`** for an invariant you want checked in dev and gone in
+  release — `NDEBUG` handles it, no wrapper needed.
+- Use `#if defined(DEBUG)` only for developer-only code that is *more* than an assert:
+  expensive diagnostics, an alternate slow-path validation, extra logging.
+- Wrapping an `assert()` in `#if defined(DEBUG)` is redundant but harmless — the
+  invariant guarantees the assert inside is live whenever the block compiles.
+- If code must disambiguate the two macros itself (as `journal`'s `api.h` does for the
+  benefit of non-mm consumers), let **`NDEBUG` dominate `DEBUG`**: explicit suppression
+  beats explicit request. mm's exclusivity makes the tie moot, but this is the
+  precedence to assume.
+
 ---
 
 ## Part 2 — Design space for mode-dependent behavior (speculative)

--- a/make/compilers/init.mm
+++ b/make/compilers/init.mm
@@ -118,6 +118,7 @@ define compiler.option.sources =
 ${strip
     $(2)
     mm
+    mode.compiler
     platform.$(1)
     $(compiler.$(1))
     $(target.variants:%=targets.%.$(1))

--- a/make/modes/default.mm
+++ b/make/modes/default.mm
@@ -9,5 +9,11 @@
 # npm: empty installs fresh ({npm i}); non-empty installs from the committed lock ({npm ci})
 mode.npm.locked := yes
 
+# compiler: whether the developer-time checks are compiled in -- the {assert}s, the code under
+# {#if defined(DEBUG)}, and journal's {debug}/{firewall} channels. this is a mode disposition,
+# orthogonal to the opt/debug optimization target; {make/modes/init.mm} turns it into the
+# coherent {DEBUG}/{NDEBUG} macro pair. the baseline is a deployment build, so the checks are off
+mode.compiler.assertions :=
+
 
 # end of file

--- a/make/modes/dev.mm
+++ b/make/modes/dev.mm
@@ -7,5 +7,9 @@
 # {dev} resolves dependencies fresh rather than from the committed lock
 mode.npm.locked :=
 
+# {dev} keeps the developer-time checks live: {assert}s fire, the {#if defined(DEBUG)} blocks
+# compile in, and journal's {debug}/{firewall} channels are real -- even in an optimized build
+mode.compiler.assertions := yes
+
 
 # end of file

--- a/make/modes/init.mm
+++ b/make/modes/init.mm
@@ -9,6 +9,21 @@ include make/modes/default.mm
 # the selected mode's overrides; a mode with no file here is a fatal error
 include make/modes/$(project.mode).mm
 
+# {mode.compiler} joins the compiler option sources as a flat, language-independent contributor,
+# just like {mm}; declare its full category set so no slot is ever an undefined variable
+mode.compiler.flags :=
+# take ownership of the two disposition macros as a coherent pair: exactly one is defined at any
+# time, so client code can never land in an ambiguous state. checks on ({assertions} set) means
+# our {DEBUG} convention and no {NDEBUG}; checks off means the standard {NDEBUG} assert guard and
+# no {DEBUG}. the exclusivity here is what makes {NDEBUG} dominate {DEBUG} -- the precedence the
+# journal api already assumes -- moot in practice
+mode.compiler.defines := ${if $(mode.compiler.assertions),DEBUG,NDEBUG}
+mode.compiler.incpath :=
+mode.compiler.ldflags :=
+mode.compiler.libpath :=
+mode.compiler.rpath :=
+mode.compiler.libraries :=
+
 # the implemented modes, discovered from the files present here, minus the framework files
 modes.available := ${filter-out init default rules model,${basename ${notdir ${wildcard $(mm.home)/make/modes/*.mm}}}}
 

--- a/make/modes/rules.mm
+++ b/make/modes/rules.mm
@@ -11,6 +11,9 @@ mode.info:
 	@${call log.var,available,$(modes.available)}
 	@${call log.sec,"  npm",}
 	@${call log.var,locked,$(mode.npm.locked)}
+	@${call log.sec,"  compiler",}
+	@${call log.var,assertions,${if $(mode.compiler.assertions),yes,no}}
+	@${call log.var,defines,$(mode.compiler.defines)}
 
 # what the build mode controls and the values it can take
 mode.help: | mm.banner
@@ -27,6 +30,7 @@ mode.help: | mm.banner
 	@$(log)
 	@${call log.sec,"settings",}
 	@${call log.help,"mode.npm.locked","install npm deps from the committed lock when set (otherwise resolve fresh)"}
+	@${call log.help,"mode.compiler.assertions","compile in the developer-time checks (asserts, DEBUG blocks, journal debug/firewall) when set"}
 	@$(log)
 
 

--- a/make/targets/debug.mm
+++ b/make/targets/debug.mm
@@ -12,10 +12,6 @@ ${eval ${call target.init,debug}}
 
 # adjust
 ${call target.adjust,debug,$(languages.compiled),flags ldflags}
-# define the DEBUG macro
-${foreach language,c c++ cuda cython fortran, \
-    ${eval targets.debug.$(language).defines += DEBUG} \
-}
 
 # build my info target
 ${eval ${call target.info.flags,debug}}

--- a/make/targets/reldeb.mm
+++ b/make/targets/reldeb.mm
@@ -12,10 +12,6 @@ ${eval ${call target.init,reldeb}}
 
 # adjust
 ${call target.adjust,reldeb,$(languages.compiled),flags ldflags}
-# define the DEBUG macro
-${foreach language,c c++ cuda cython fortran, \
-    ${eval targets.reldeb.$(language).defines += DEBUG} \
-}
 
 # build my info target
 ${eval ${call target.info.flags,reldeb}}


### PR DESCRIPTION
## Summary

Whether a build compiles in its developer-time checks — the `assert`s, the code under `#if defined(DEBUG)`, and `journal`'s `debug`/`firewall` channels — is now a **dev/release mode** disposition, orthogonal to the **opt/debug optimization target**. An optimized developer build still checks its invariants; a release build drops them regardless of optimization level.

Previously the `DEBUG` macro was defined by the `debug`/`reldeb` targets, so assert liveness rode the optimization axis. The default local build is `opt`, which defined neither `DEBUG` nor `NDEBUG` — leaving `assert()` nominally live but every `#if defined(DEBUG)` check (and `journal`'s `firewall_t`) compiled out. That inconsistency let a real bug ride through every local run and surface only in CI's debug legs.

## The convention

`DEBUG` (our convention) and `NDEBUG` (the standard `<cassert>` guard) are independent macros; all four combinations are reachable and two are incoherent. mm now owns them as a coherent pair: **exactly one is defined at all times**, so client code can never land in an ambiguous state.

- **dev** → `-DDEBUG`, no `NDEBUG`: developer code in, `assert()` live, `journal` developer channels real.
- **release / conda / macports / ubuntu** → `-DNDEBUG`, no `DEBUG`: developer code gone, `assert()` a no-op, developer channels `null_t`.

## Changes

- `make/modes/default.mm` / `dev.mm` — knob `mode.compiler.assertions` (baseline empty; `yes` in dev).
- `make/modes/init.mm` — the single ownership point: `mode.compiler.defines := ${if $(mode.compiler.assertions),DEBUG,NDEBUG}`, plus the full flat category set so the source trips no `-warn-undefined`.
- `make/compilers/init.mm` — `mode.compiler` added to `compiler.option.sources` as a flat, language-independent source (same shape as `mm`).
- `make/targets/debug.mm` / `reldeb.mm` — `DEBUG` removed; targets are now purely optimization/symbols.
- `make/modes/rules.mm` — `mode.info` / `mode.help` advertise the knob.
- `docs/modes.md` — "Second consumer" section: the coherence table and client-code guidance.

## Verification

Compile-line matrix on the `step01` timer example:

| mode / target | defines | symbols |
|---|---|---|
| dev / opt | `-DDEBUG` | none |
| release / opt | `-DNDEBUG` | none |
| dev / debug | `-DDEBUG` | `-g` |
| release / debug | `-DNDEBUG` | `-g` |

Optimization and disposition are fully decoupled; no undefined-variable warnings; full example build + tests green.

## Behavior change

Release/deployment modes now define `-DNDEBUG`, newly silencing bare (unwrapped) `assert()` in release. Default local builds (opt+dev) now compile in `journal` `debug`/`firewall` channels and keep asserts live.